### PR TITLE
Introduce HTTP unit testing at Get Template

### DIFF
--- a/dev/setup_db.sh
+++ b/dev/setup_db.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 set -e
-echo Wait for servers to be up
+
+echo "Wait for servers to be up"
 sleep 10
 
-HOSTPARAMS="--host roach-one --insecure"
+HOSTPARAMS="--host db --insecure"
 SQL="/cockroach/cockroach.sh sql $HOSTPARAMS"
 
-$SQL -e "CREATE DATABASE IF NOT EXISTS triton;"
-$SQL -d triton -e "CREATE TABLE IF NOT EXISTS tsg_templates (id SERIAL PRIMARY KEY, name TEXT NOT NULL, package TEXT NOT NULL, image_id TEXT NOT NULL, account_id TEXT NOT NULL, firewall_enabled BOOL DEFAULT false, networks TEXT, metadata TEXT, userdata TEXT, tags TEXT, archived BOOL DEFAULT false);"
-$SQL -d triton -e "CREATE TABLE IF NOT EXISTS tsg_groups (id SERIAL PRIMARY KEY, name TEXT NOT NULL, template_id INT NOT NULL REFERENCES tsg_templates (id), account_id TEXT NOT NULL, capacity INT NOT NULL, datacenter TEXT NOT NULL, health_check_interval INT DEFAULT 300, instance_tags TEXT, archived BOOL DEFAULT false);"
+for env in triton triton_test; do
+    $SQL -e "CREATE DATABASE IF NOT EXISTS ${env};"
+    $SQL -d $env -e "CREATE TABLE IF NOT EXISTS tsg_templates (id SERIAL PRIMARY KEY, name TEXT NOT NULL, package TEXT NOT NULL, image_id TEXT NOT NULL, account_id TEXT NOT NULL, firewall_enabled BOOL DEFAULT false, networks TEXT, metadata TEXT, userdata TEXT, tags TEXT, archived BOOL DEFAULT false);"
+    $SQL -d $env -e "CREATE TABLE IF NOT EXISTS tsg_groups (id SERIAL PRIMARY KEY, name TEXT NOT NULL, template_id INT NOT NULL REFERENCES tsg_templates (id), account_id TEXT NOT NULL, capacity INT NOT NULL, datacenter TEXT NOT NULL, health_check_interval INT DEFAULT 300, instance_tags TEXT, archived BOOL DEFAULT false);"
+done
 
 /cockroach/cockroach.sh sql $HOSTPARAMS --database=triton < /dev/backup.sql

--- a/dev/setup_db.sh
+++ b/dev/setup_db.sh
@@ -11,6 +11,7 @@ for env in triton triton_test; do
     $SQL -e "CREATE DATABASE IF NOT EXISTS ${env};"
     $SQL -d $env -e "CREATE TABLE IF NOT EXISTS tsg_templates (id SERIAL PRIMARY KEY, name TEXT NOT NULL, package TEXT NOT NULL, image_id TEXT NOT NULL, account_id TEXT NOT NULL, firewall_enabled BOOL DEFAULT false, networks TEXT, metadata TEXT, userdata TEXT, tags TEXT, archived BOOL DEFAULT false);"
     $SQL -d $env -e "CREATE TABLE IF NOT EXISTS tsg_groups (id SERIAL PRIMARY KEY, name TEXT NOT NULL, template_id INT NOT NULL REFERENCES tsg_templates (id), account_id TEXT NOT NULL, capacity INT NOT NULL, datacenter TEXT NOT NULL, health_check_interval INT DEFAULT 300, instance_tags TEXT, archived BOOL DEFAULT false);"
+    /cockroach/cockroach.sh sql $HOSTPARAMS --database=$env < /dev/backup.sql
 done
 
-/cockroach/cockroach.sh sql $HOSTPARAMS --database=triton < /dev/backup.sql
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,25 @@
-version: '2'
+version: '2.1'
 
 services:
-  roach-ui:
-    image: cockroachdb/cockroach
+
+  db:
+    image: cockroachdb/cockroach:v1.1.4
     command: start --insecure
     ports:
       - 8080:8080
-    networks:
-        - roachnet
+      - 26257:26257
     volumes:
-      - ./data/roach-ui:/cockroach/cockroach-data
-  roach-one:
-    image: cockroachdb/cockroach
-    command: start --insecure --join=roach-ui
-    ports:
-        - 26257:26257
-    networks:
-        - roachnet
-    volumes:
-      - ./data/roach-one:/cockroach/cockroach-data
-  roach-init:
-     image: cockroachdb/cockroach
-     networks:
-      - roachnet
+      - ./data/cockroach-data:/cockroach/cockroach-data
+    restart: always
+    network_mode: bridge
+
+  init:
+     image: cockroachdb/cockroach:v1.1.4
      volumes:
        - ./dev/setup_db.sh:/setup_db.sh
        - ./dev/backup.sql:/dev/backup.sql
      entrypoint: "/bin/bash"
      command: /setup_db.sh
-
-networks:
-  roachnet:
+     links:
+       - db
+     network_mode: bridge

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func initDb() (*pgx.ConnPool, error) {
 		AcquireTimeout: 0,
 		ConnConfig: pgx.ConnConfig{
 			Host:     "localhost",
-			Database: "tsg",
+			Database: "triton",
 			Port:     26257,
 			User:     "root",
 		},

--- a/templates/machine_v1_test.go
+++ b/templates/machine_v1_test.go
@@ -1,0 +1,56 @@
+package templates_v1_test
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jackc/pgx"
+	"github.com/joyent/triton-service-groups/session"
+	templates_v1 "github.com/joyent/triton-service-groups/templates"
+	"github.com/stretchr/testify/assert"
+)
+
+// TODO: We should refactor how/where our database initializes so we can half
+// bootstrap the application from our tests with a simple one-liner.
+func initDB() (*pgx.ConnPool, error) {
+	connPool, err := pgx.NewConnPool(pgx.ConnPoolConfig{
+		MaxConnections: 5,
+		AfterConnect:   nil,
+		AcquireTimeout: 0,
+		ConnConfig: pgx.ConnConfig{
+			Host:     "localhost",
+			Database: "triton_test",
+			Port:     26257,
+			User:     "root",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return connPool, nil
+}
+
+func TestList(t *testing.T) {
+	dbpool, err := initDB()
+	if err != nil {
+		log.Fatal(err)
+	}
+	session := &session.TsgSession{
+		DbPool: dbpool,
+	}
+
+	req := httptest.NewRequest("GET", "http://example.com/tsg/v1/templates", nil)
+	recorder := httptest.NewRecorder()
+	templates_v1.List(session)(recorder, req)
+
+	resp := recorder.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+	assert.Equal(t, "null", string(body))
+}


### PR DESCRIPTION
This PR introduces HTTP unit testing. We manually bootstrap the application within the test to provide everything required to hit the endpoint. This means, for the moment, we're also exercising our connection to CockroachDB as well.

I've also slimmed down our `docker-compose.yml` file and added bootstrapping two databases, one for dev and one for dev testing.