### PR TITLE
Lowercase all returned API JSON

### DIFF
--- a/groups/groups_v1.go
+++ b/groups/groups_v1.go
@@ -16,12 +16,12 @@ import (
 )
 
 type ServiceGroup struct {
-	ID                  int64
-	GroupName           string
-	TemplateId          int64
-	AccountId           string
-	Capacity            int
-	HealthCheckInterval int
+	ID                  int64  `json:"id"`
+	GroupName           string `json:"group_name"`
+	TemplateId          int64  `json:"template_id"`
+	AccountId           string `json:"account_id"`
+	Capacity            int    `json:"capacity"`
+	HealthCheckInterval int    `json:"health_check_interval"`
 }
 
 func Get(session *session.TsgSession) http.HandlerFunc {

--- a/templates/instance_v1.go
+++ b/templates/instance_v1.go
@@ -16,17 +16,17 @@ import (
 )
 
 type InstanceTemplate struct {
-	ID                 int64
-	TemplateName       string
-	AccountId          string
-	Package            string
-	ImageId            string
-	InstanceNamePrefix string
-	FirewallEnabled    bool
-	Networks           []string
-	UserData           string
-	MetaData           map[string]string
-	Tags               map[string]string
+	ID                 int64             `json:"id"`
+	TemplateName       string            `json:"template_name"`
+	AccountId          string            `json:"account_id"`
+	Package            string            `json:"package"`
+	ImageId            string            `json:"image_id"`
+	InstanceNamePrefix string            `json:"instance_name_prefix"`
+	FirewallEnabled    bool              `json:"firewall_enabled"`
+	Networks           []string          `json:"networks"`
+	UserData           string            `json:"userdata"`
+	MetaData           map[string]string `json:"metadata"`
+	Tags               map[string]string `json:"tags"`
 }
 
 func Get(session *session.TsgSession) http.HandlerFunc {

--- a/templates/instance_v1_test.go
+++ b/templates/instance_v1_test.go
@@ -64,7 +64,7 @@ func TestAcc_Get(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
 
-	testBody := "{\"ID\":319209784155176962,\"TemplateName\":\"test-template-1\",\"AccountId\":\"joyent\",\"Package\":\"test-package\",\"ImageId\":\"49b22aec-0c8a-11e6-8807-a3eb4db576ba\",\"InstanceNamePrefix\":\"sample-\",\"FirewallEnabled\":false,\"Networks\":[\"f7ed95d3-faaf-43ef-9346-15644403b963\"],\"UserData\":\"bash script here\",\"MetaData\":null,\"Tags\":null}"
+	testBody := "{\"id\":319209784155176962,\"template_name\":\"test-template-1\",\"account_id\":\"joyent\",\"package\":\"test-package\",\"image_id\":\"49b22aec-0c8a-11e6-8807-a3eb4db576ba\",\"instance_name_prefix\":\"sample-\",\"firewall_enabled\":false,\"networks\":[\"f7ed95d3-faaf-43ef-9346-15644403b963\"],\"userdata\":\"bash script here\",\"metadata\":null,\"tags\":null}"
 	assert.Equal(t, testBody, string(body))
 }
 
@@ -201,21 +201,21 @@ func TestAcc_CreateTemplate(t *testing.T) {
 	}
 
 	testBody := `{
-	"TemplateName": "test-template-7",
-		"AccountId": "joyent",
-		"Package": "test-package",
-		"ImageId": "49b22aec-0c8a-11e6-8807-a3eb4db576ba",
-		"InstanceNamePrefix": "sample-",
-		"FirewallEnabled": false,
-		"Networks": [
+	"template_name": "test-template-7",
+		"account_id": "joyent",
+		"package": "test-package",
+		"image_id": "49b22aec-0c8a-11e6-8807-a3eb4db576ba",
+		"instance_name_prefix": "sample-",
+		"firewall_enabled": false,
+		"networks": [
 	"f7ed95d3-faaf-43ef-9346-15644403b963"
 	],
-	"UserData": "bash script here",
-		"Tags": {
+	"userdata": "bash script here",
+		"tags": {
 	"foo": "bar",
 	"owner": "stack72"
 	},
-	"MetaData": null
+	"metadata": null
 }`
 
 	r := bytes.NewReader([]byte(testBody))


### PR DESCRIPTION
This PR lowercases all keys returned through the API as JSON. Conforms to community standards for APIs and would be nice before wrapping up the `triton-go` and Terraform demo work.