### PR TITLE
routes: CreateGroup and ListGroups should not end in a slash

### DIFF
--- a/router/routes.go
+++ b/router/routes.go
@@ -49,7 +49,7 @@ var groupRoutes = Routes{
 	Route{
 		"CreateGroup",
 		http.MethodPost,
-		"/v1/tsg/",
+		"/v1/tsg",
 		groups_v1.Create,
 	},
 	Route{
@@ -67,7 +67,7 @@ var groupRoutes = Routes{
 	Route{
 		"ListGroups",
 		http.MethodGet,
-		"/v1/tsg/",
+		"/v1/tsg",
 		groups_v1.List,
 	},
 }


### PR DESCRIPTION
We can talk about this one but I feel like we should move to `/v1/tsg/groups`. Feels like the `/tsg` is an application mount point in the URI and not necessarily a resource endpoint. This isn't a big deal but at the very least we should remove the trailing slash with this PR.

`triton-go` client changes utilize this PR.