### PR TITLE
docs: Clean up documentation and text used by our agent command

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -13,8 +13,22 @@ import (
 
 var agentCmd = &cobra.Command{
 	Use:   "agent",
-	Short: buildtime.PROGNAME + ` agent process`,
-	Long:  fmt.Sprintf(`Starts the %s agent and runs until an interrupt is received.`, buildtime.PROGNAME),
+	Short: buildtime.PROGNAME + ` API server agent runner`,
+	Long: fmt.Sprintf(`
+%s - Triton Service Groups API
+
+Runs the Triton Service Groups API server as an agent process.
+
+The agent includes reading in the default and environment configuration then
+serving the HTTP API. The HTTP server is configurable and can be bound to any
+interface or port. Note that the server is configured to use keep alive by
+default (Go standard library) in order to follow HTTP/1.1.
+
+Agent will continue to run in the foreground until an interrupt signal has been
+received. Sending SIGINT or SIGTERM will drain/shutdown all HTTP connections
+gracefully, while performing a SIGKILL will not.
+
+`, buildtime.PROGNAME),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Info().Msgf("agent: starting %s agent", buildtime.PROGNAME)

--- a/cli/root.go
+++ b/cli/root.go
@@ -28,10 +28,16 @@ var (
 
 var RootCmd = &cobra.Command{
 	Use:   buildtime.PROGNAME,
-	Short: buildtime.PROGNAME + `provides a Nomad based service API`,
-	Long: `
-Provides an experimental application structure for testing a Nomad based service API.
-`,
+	Short: buildtime.PROGNAME + `is the Triton Service Groups API`,
+	Long: fmt.Sprintf(`
+%s - Triton Service Groups API
+
+Everything used to configure and run the central API server of the Triton
+Service Groups service. Includes configuring default values, database and client
+connections settings, environment variable overrides, binding and serving HTTP
+access, and optionally enabling introspective utilities like gops(1) and pprof.
+
+`, buildtime.PROGNAME),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Re-initialize logging with user-supplied configuration parameters
 		{

--- a/cli/version.go
+++ b/cli/version.go
@@ -10,16 +10,21 @@ import (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: buildtime.PROGNAME + ` version information`,
-	Long:  fmt.Sprintf(`Display %s version information`, buildtime.PROGNAME),
+	Long: fmt.Sprintf(`
+%s - Triton Service Groups API
+
+Displays version, SCM, and build information.
+
+`, buildtime.PROGNAME),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Printf("%s:\n", buildtime.PROGNAME)
-		fmt.Printf("\tversion: %s\n", buildtime.Version)
-		fmt.Printf("\tdate: %s\n", buildtime.BuildDate)
-		fmt.Printf("\tcommit: %s\n", buildtime.GitCommit)
-		fmt.Printf("\tbranch: %s\n", buildtime.GitBranch)
-		fmt.Printf("\tstate: %s\n", buildtime.GitState)
-		fmt.Printf("\tsummary: %s\n", buildtime.GitSummary)
+		fmt.Printf("%s\n\n", buildtime.PROGNAME)
+		fmt.Printf("Version: %s\n", buildtime.Version)
+		fmt.Printf("Date: %s\n", buildtime.BuildDate)
+		fmt.Printf("Commit: %s\n", buildtime.GitCommit)
+		fmt.Printf("Branch: %s\n", buildtime.GitBranch)
+		fmt.Printf("State: %s\n", buildtime.GitState)
+		fmt.Printf("Summary: %s\n", buildtime.GitSummary)
 
 		return nil
 	},


### PR DESCRIPTION
Simply removing placeholder cruft.

/cc @stack72 @kwilczynski 