### PR TITLE
groups: Added increment and decrement endpoints

### DIFF
--- a/groups/groups.go
+++ b/groups/groups.go
@@ -185,6 +185,114 @@ func List(w http.ResponseWriter, r *http.Request) {
 	writeJsonResponse(w, bytes)
 }
 
+type ActionableInput struct {
+	InstanceCount int
+	MaxInstance   int
+	MinInstance   int
+}
+
+func Increment(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	session := handlers.GetAuthSession(ctx)
+
+	vars := mux.Vars(r)
+	identifier := vars["identifier"]
+
+	// Get the Current Group Config
+	id, err := strconv.Atoi(identifier)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	group, ok := FindGroupByID(ctx, int64(id), session.AccountID)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	input, err := buildActionableInput(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if group.Capacity >= input.MaxInstance {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	//Set the new Capacity based on rules
+	if group.Capacity+input.InstanceCount > input.MaxInstance {
+		group.Capacity = input.MaxInstance
+	} else {
+		group.Capacity = group.Capacity + input.InstanceCount
+	}
+
+	//Update the Database and the orchestration job
+	UpdateGroup(ctx, identifier, session.AccountID, group)
+
+	err = UpdateOrchestratorJob(ctx, group)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	//Return a 202 to suggest accepted
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func Decrement(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	session := handlers.GetAuthSession(ctx)
+
+	vars := mux.Vars(r)
+	identifier := vars["identifier"]
+
+	// Get the Current Group Config
+	id, err := strconv.Atoi(identifier)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	group, ok := FindGroupByID(ctx, int64(id), session.AccountID)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	input, err := buildActionableInput(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if group.Capacity <= input.MinInstance {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	//Set the new Capacity based on rules
+	if group.Capacity-input.InstanceCount < input.MinInstance {
+		group.Capacity = input.MinInstance
+	} else {
+		group.Capacity = group.Capacity - input.InstanceCount
+	}
+
+	//Update the Database and the orchestration job
+	UpdateGroup(ctx, identifier, session.AccountID, group)
+
+	err = UpdateOrchestratorJob(ctx, group)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	//Return a 202 to suggest accepted
+	w.WriteHeader(http.StatusAccepted)
+}
+
 func writeJsonResponse(w http.ResponseWriter, bytes []byte) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	if n, err := w.Write(bytes); err != nil {
@@ -192,4 +300,19 @@ func writeJsonResponse(w http.ResponseWriter, bytes []byte) {
 	} else if n != len(bytes) {
 		log.Printf("short write: %d/%d", n, len(bytes))
 	}
+}
+
+func buildActionableInput(r *http.Request) (*ActionableInput, error) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var input *ActionableInput
+	err = json.Unmarshal(body, &input)
+	if err != nil {
+		return nil, err
+	}
+
+	return input, nil
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -66,6 +66,18 @@ var groupRoutes = router.Routes{
 		Pattern: "/v1/tsg",
 		Handler: groups_v1.List,
 	},
+	router.Route{
+		Name:    "IncrementGroupCapacity",
+		Method:  http.MethodPut,
+		Pattern: "/v1/tsg/{identifier}/increment",
+		Handler: groups_v1.Increment,
+	},
+	router.Route{
+		Name:    "DecrementGroupCapacity",
+		Method:  http.MethodPut,
+		Pattern: "/v1/tsg/{identifier}/decrement",
+		Handler: groups_v1.Decrement,
+	},
 }
 
 var RoutingTable = router.RouteTable{


### PR DESCRIPTION
Fixes #21

This adds the ability to not pass a state to the api - instead it accepts a
group Id, a number of instances to increase / decreate by then a max and a
min value for the range in which to stay between

The API will act in 3 ways:

1. We will return a 404 for a Group NotFound
2. We will return a 400 for when the current capactity >= MaxRange and an
instance increase was requested
3. We will return a 202 and try to honor the request by adding as many of
the requested instances to the current capacity until we hit the range
limit