### PR TITLE
Handle new lines when a key body is passed through TRITON_KEY_MATERIAL.

### DIFF
--- a/groups/orchestrator.go
+++ b/groups/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"text/template"
 
@@ -222,7 +223,9 @@ func createJobDetails(template *templates_v1.InstanceTemplate, group *ServiceGro
 	job.TritonAccount = os.Getenv("TRITON_ACCOUNT")
 	job.TritonURL = os.Getenv("TRITON_URL")
 	job.TritonKeyID = os.Getenv("TRITON_KEY_ID")
-	job.TritonKeyMaterial = os.Getenv("TRITON_KEY_MATERIAL")
+
+	keyMaterial := strings.Replace(os.Getenv("TRITON_KEY_MATERIAL"), "\n", `\n`, -1)
+	job.TritonKeyMaterial = keyMaterial
 
 	return job
 }


### PR DESCRIPTION
This commit fixes a problem where the new lines have been passed as-is to the underlying
Nomad job spec template, causing multiple spurious new lines to appear in the middle
resulting in an invalid HCL causing the parser to fail with an error.

An example would be:

```shell
  $ export TRITON_KEY_MATERIAL=$(cat /Users/kwilczynski/.ssh/id_rsa)
```
The above would store the key in a PEM format as-is, with all the new lines, and
it would be enough to cause the problems when the template is being rendered to
use the `--key-material` command line switch with the tsg binary.

Signed-off-by: Krzysztof Wilczynski <kwilczynski@joyent.com>