### PR TITLE
handlers: Add configured Nomad client into request context

### DIFF
--- a/agent/nomad.go
+++ b/agent/nomad.go
@@ -1,0 +1,31 @@
+package agent
+
+import (
+	"fmt"
+
+	nomad "github.com/hashicorp/nomad/api"
+	"github.com/rs/zerolog/log"
+)
+
+func (a *Agent) ensureNomadClient() error {
+	log.Debug().Msg("agent: connecting to job scheduler")
+
+	nomadCfg := nomad.DefaultConfig()
+	scheme := "http"
+
+	if a.config.Nomad.TLSConfig != nil {
+		nomadCfg.TLSConfig = a.config.Nomad.TLSConfig
+		scheme = "https"
+	}
+
+	nomadCfg.Address = fmt.Sprintf("%s://%s:%d",
+		scheme, a.config.Nomad.Addr, a.config.Nomad.Port)
+
+	c, err := nomad.NewClient(nomadCfg)
+	if err != nil {
+		return err
+	}
+	a.nomad = c
+
+	return nil
+}

--- a/server/handlers/context.go
+++ b/server/handlers/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	nomad "github.com/hashicorp/nomad/api"
 	"github.com/jackc/pgx"
 )
 
@@ -12,12 +13,19 @@ type contextKey int
 const (
 	dbKeyName contextKey = iota
 	authKey
+	nomadKeyName
 )
 
 type dbValue struct {
 	pool *pgx.ConnPool
 }
 
+type nomadValue struct {
+	client *nomad.Client
+}
+
+// GetDBPool pulls a configured database client out of the current request
+// context.
 func GetDBPool(ctx context.Context) (*pgx.ConnPool, bool) {
 	if db, ok := ctx.Value(dbKeyName).(dbValue); ok {
 		return db.pool, true
@@ -25,14 +33,25 @@ func GetDBPool(ctx context.Context) (*pgx.ConnPool, bool) {
 	return nil, false
 }
 
+// GetNomadClient pulls a configured nomad client out of the current request
+// context.
+func GetNomadClient(ctx context.Context) (*nomad.Client, bool) {
+	if nomad, ok := ctx.Value(nomadKeyName).(nomadValue); ok {
+		return nomad.client, true
+	}
+	return nil, false
+}
+
 type contextHandler struct {
 	pool    *pgx.ConnPool
+	nomad   *nomad.Client
 	handler http.Handler
 }
 
-func ContextHandler(pool *pgx.ConnPool, h http.Handler) *contextHandler {
+func ContextHandler(pool *pgx.ConnPool, nomad *nomad.Client, h http.Handler) *contextHandler {
 	return &contextHandler{
 		pool:    pool,
+		nomad:   nomad,
 		handler: h,
 	}
 }

--- a/server/handlers/errors.go
+++ b/server/handlers/errors.go
@@ -3,7 +3,8 @@ package handlers
 import "errors"
 
 var (
-	ErrNoConnPool = errors.New("handlers can't access database pool")
-	ErrFailedAuth = errors.New("failed request authentication")
-	ErrNoSession  = errors.New("failed to get authenticated session")
+	ErrNoConnPool    = errors.New("handlers can't access database pool")
+	ErrNoNomadClient = errors.New("handlers can't access nomad client")
+	ErrFailedAuth    = errors.New("failed request authentication")
+	ErrNoSession     = errors.New("failed to get authenticated session")
 )


### PR DESCRIPTION
This commit configures the Nomad client exactly how we currently construct the database client. We first pull in configuration values into our main `config.Config` abstraction within `config.Nomad` struct. Upon bootstrapping the agent process we use this config to construct a Nomad configuration and client. This client is fed into the `server.HTTPServer` and passed into the `handlers.ContextHandler`. Finally, we introduce a handler function to pull the Nomad client back out of the `context.Context` running through every HTTP request, called `handlers.GetNomadClient`. This should now configure the client available to all orchestration processes.

Fixes #29