### PR TITLE
Post-auth merge fixes

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,10 +20,11 @@ test:: ## Run unit tests
 
 testacc:: ## Run acceptance tests
 	@echo "==> Running acceptance tests"
-	TRITON_TEST=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TSG_TEST=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
 check::
 	gometalinter \
+			--skip=examples \
 			--deadline 10m \
 			--vendor \
 			--sort="path" \

--- a/README.md
+++ b/README.md
@@ -1,21 +1,31 @@
 # triton-service-groups
 
-The following environment variables are still required to demo.
-
-```
-NOMAD_URL
-TRITON_ACCOUNT
-TRITON_URL
-TRITON_KEY_ID
-TRITON_KEY_MATERIAL
-```
-
 ## Run
 
 ```sh
 $ make build
 $ bin/triton-sg agent --log-level=DEBUG
 ```
+
+While developing eveything besides scaling actions you can rely on `TSG_DEV_MODE=1` to skip authentication.
+
+```sh
+$ TSG_DEV_MODE=1 bin/triton-sg agent --log-level=DEBUG
+```
+
+When dev mode is enabled any request sent to the TSG API (regardless of headerS) will be linked to the seed data we've provided within `./dev/setup_db.sh`. This data is only provided as a stub and will not work against Triton's CloudAPI.
+
+### Whitelist
+
+Authentication provides a whitelisting feature which only allows incoming requests to be authenticated if the account has been entered into the TSG database. If whitelisting is not enabled than all Triton accounts that can be authenticated with CloudAPI will generate a new account and key within the TSG API.
+
+The following SQL is a snippet for adding your Triton account to TSG.
+
+```sql
+INSERT INTO tsg_accounts (account_name, triton_uuid, created_at, updated_at) VALUES ('demouser', 'd82a1f04-b9f6-4075-998f-af20e3d49de6', NOW(), NOW());
+```
+
+To turn off whitelisting requires changing a boolean within `server/handlers/auth/consts.go`. Set `isWhitelistOnly` to either `true` or `false`. `true` is the default. A new build of TSG must include this change as it is not yet configurable within the config file or env var.
 
 ## Environment
 

--- a/accounts/account_test.go
+++ b/accounts/account_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestNew(t *testing.T) {
 	if os.Getenv("TSG_TEST") == "" {
-		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST=1' set")
+		t.Skip("Acceptance tests skipped unless env 'TSG_TEST=1' set")
 		return
 	}
 
@@ -33,7 +33,7 @@ func TestNew(t *testing.T) {
 
 func TestInsert(t *testing.T) {
 	if os.Getenv("TSG_TEST") == "" {
-		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST=1' set")
+		t.Skip("Acceptance tests skipped unless env 'TSG_TEST=1' set")
 		return
 	}
 
@@ -66,7 +66,7 @@ func TestInsert(t *testing.T) {
 
 func TestSave(t *testing.T) {
 	if os.Getenv("TSG_TEST") == "" {
-		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST=1' set")
+		t.Skip("Acceptance tests skipped unless env 'TSG_TEST=1' set")
 		return
 	}
 
@@ -108,7 +108,7 @@ func TestSave(t *testing.T) {
 
 func TestExists(t *testing.T) {
 	if os.Getenv("TSG_TEST") == "" {
-		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST=1' set")
+		t.Skip("Acceptance tests skipped unless env 'TSG_TEST=1' set")
 		return
 	}
 
@@ -162,7 +162,7 @@ func TestExists(t *testing.T) {
 	}
 
 	account.AccountName = ""
-	account.ID = 0
+	account.ID = ""
 
 	// false and error if account does not include any fields
 	{

--- a/accounts/store.go
+++ b/accounts/store.go
@@ -20,7 +20,7 @@ func NewStore(pool *pgx.ConnPool) *Store {
 }
 
 // FindByID finds an account by a specific ID.
-func (s *Store) FindByID(ctx context.Context, accountID int64) (*Account, error) {
+func (s *Store) FindByID(ctx context.Context, accountID string) (*Account, error) {
 	var (
 		id        pgtype.UUID
 		keyID     pgtype.UUID

--- a/accounts/store_test.go
+++ b/accounts/store_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestFindByID(t *testing.T) {
 	if os.Getenv("TSG_TEST") == "" {
-		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST=1' set")
+		t.Skip("Acceptance tests skipped unless env 'TSG_TEST=1' set")
 		return
 	}
 
@@ -49,7 +49,7 @@ func TestFindByID(t *testing.T) {
 
 func TestFindByName(t *testing.T) {
 	if os.Getenv("TSG_TEST") == "" {
-		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST=1' set")
+		t.Skip("Acceptance tests skipped unless env 'TSG_TEST=1' set")
 		return
 	}
 

--- a/dev/backup.sql
+++ b/dev/backup.sql
@@ -6,8 +6,11 @@ DELETE FROM tsg_keys;
 DELETE FROM tsg_users;
 DELETE FROM tsg_accounts;
 
-INSERT INTO tsg_accounts (id, account_name, triton_uuid, created_at, updated_at)
-VALUES ('6f873d02-172c-418f-8416-4da2b50d5c53', 'joyent', '87307a00-ab96-4fec-8df7-1a256e49fbcc', NOW(), NOW());
+INSERT INTO tsg_keys (id, name, fingerprint, material, created_at, updated_at)
+VALUES ('1d32f239-81e2-4e35-a258-a5649dc4e6f3', 'TSG_Management', '5a:ce:1e:1d:b0:96:78:c6:7a:f2:f8:26:e1:b3:55:79', 'just a test ssh private key yo', NOW(), NOW());
+
+INSERT INTO tsg_accounts (id, account_name, triton_uuid, key_id, created_at, updated_at)
+VALUES ('6f873d02-172c-418f-8416-4da2b50d5c53', 'joyent', '87307a00-ab96-4fec-8df7-1a256e49fbcc', '1d32f239-81e2-4e35-a258-a5649dc4e6f3', NOW(), NOW());
 
 INSERT INTO tsg_templates (id, template_name, package, image_id, account_id, instance_name_prefix, firewall_enabled, networks, metadata, userdata, tags, archived) VALUES
     ('ad74301e-ad62-404a-be44-3b2f24d082ac', 'test-template-1', 'test-package', '49b22aec-0c8a-11e6-8807-a3eb4db576ba', '6f873d02-172c-418f-8416-4da2b50d5c53', 'sample-', false, 'f7ed95d3-faaf-43ef-9346-15644403b963', NULL, 'bash script here', NULL, false),

--- a/groups/orchestrator.go
+++ b/groups/orchestrator.go
@@ -191,7 +191,7 @@ func prepareJob(t *templates_v1.InstanceTemplate, group *ServiceGroup) (*nomad.J
 func createJobDetails(template *templates_v1.InstanceTemplate, group *ServiceGroup) OrchestratorJob {
 	job := OrchestratorJob{
 		AccountID:           group.AccountID,
-		JobName:             fmt.Sprintf("%s_%d", group.GroupName, template.ID),
+		JobName:             fmt.Sprintf("%s_%s", group.GroupName, template.ShortID()),
 		HealthCheckInterval: group.HealthCheckInterval,
 		DesiredCount:        group.Capacity,
 		PackageID:           template.Package,

--- a/keys/key.go
+++ b/keys/key.go
@@ -103,8 +103,14 @@ func (k *Key) Exists(ctx context.Context) (bool, error) {
 SELECT 1 FROM tsg_keys
 WHERE (id = $1 OR name = $2) AND archived = false;
 `
+	// NOTE(justinwr): seriously...
+	keyID := "00000000-0000-0000-0000-000000000000"
+	if k.ID != "" {
+		keyID = k.ID
+	}
+
 	err := k.store.pool.QueryRowEx(ctx, query, nil,
-		k.ID,
+		keyID,
 		k.Name,
 	).Scan(&count)
 	switch err {

--- a/keys/key.go
+++ b/keys/key.go
@@ -115,6 +115,4 @@ WHERE (id = $1 OR name = $2) AND archived = false;
 	default:
 		return false, errors.Wrap(err, "failed to check key existence")
 	}
-
-	return true, nil
 }

--- a/keys/key_test.go
+++ b/keys/key_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestNew(t *testing.T) {
 	if os.Getenv("TSG_TEST") == "" {
-		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST=1' set")
+		t.Skip("Acceptance tests skipped unless env 'TSG_TEST=1' set")
 		return
 	}
 
@@ -33,7 +33,7 @@ func TestNew(t *testing.T) {
 
 func TestInsert(t *testing.T) {
 	if os.Getenv("TSG_TEST") == "" {
-		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST=1' set")
+		t.Skip("Acceptance tests skipped unless env 'TSG_TEST=1' set")
 		return
 	}
 
@@ -69,7 +69,7 @@ func TestInsert(t *testing.T) {
 
 func TestSave(t *testing.T) {
 	if os.Getenv("TSG_TEST") == "" {
-		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST=1' set")
+		t.Skip("Acceptance tests skipped unless env 'TSG_TEST=1' set")
 		return
 	}
 
@@ -114,7 +114,7 @@ func TestSave(t *testing.T) {
 
 func TestExists(t *testing.T) {
 	if os.Getenv("TSG_TEST") == "" {
-		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST=1' set")
+		t.Skip("Acceptance tests skipped unless env 'TSG_TEST=1' set")
 		return
 	}
 

--- a/keys/key_test.go
+++ b/keys/key_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/joyent/triton-service-groups/keys"
 	"github.com/joyent/triton-service-groups/testutils"
@@ -96,8 +95,6 @@ func TestSave(t *testing.T) {
 	assert.Equal(t, key.CreatedAt, key.UpdatedAt)
 
 	key.Name = "hackerman"
-
-	time.Sleep(1 * time.Second)
 
 	err = key.Save(context.Background())
 	require.NoError(t, err)

--- a/keys/store_test.go
+++ b/keys/store_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestFindByID(t *testing.T) {
 	if os.Getenv("TSG_TEST") == "" {
-		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST=1' set")
+		t.Skip("Acceptance tests skipped unless env 'TSG_TEST=1' set")
 		return
 	}
 
@@ -52,7 +52,7 @@ func TestFindByID(t *testing.T) {
 
 func TestFindByName(t *testing.T) {
 	if os.Getenv("TSG_TEST") == "" {
-		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST=1' set")
+		t.Skip("Acceptance tests skipped unless env 'TSG_TEST=1' set")
 		return
 	}
 

--- a/server/handlers/auth.go
+++ b/server/handlers/auth.go
@@ -50,19 +50,21 @@ func (a authHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	accountStore := accounts.NewStore(a.pool)
+	if !session.IsDevMode() {
+		accountStore := accounts.NewStore(a.pool)
 
-	acct, err := session.EnsureAccount(ctx, accountStore)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusUnauthorized)
-		return
-	}
+		acct, err := session.EnsureAccount(ctx, accountStore)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
 
-	keyStore := keys.NewStore(a.pool)
+		keyStore := keys.NewStore(a.pool)
 
-	if err := session.EnsureKeys(ctx, acct, keyStore); err != nil {
-		http.Error(w, err.Error(), http.StatusUnauthorized)
-		return
+		if err := session.EnsureKeys(ctx, acct, keyStore); err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
 	}
 
 	if !session.IsAuthenticated() {

--- a/server/handlers/auth/consts.go
+++ b/server/handlers/auth/consts.go
@@ -11,5 +11,6 @@ const (
 	// to the tsg_accounts table, auto account creation will be disabled
 	isWhitelistOnly = true
 
-	testAccountID = "6f873d02-172c-418f-8416-4da2b50d5c53"
+	testAccountID   = "6f873d02-172c-418f-8416-4da2b50d5c53"
+	testFingerprint = "5a:ce:1e:1d:b0:96:78:c6:7a:f2:f8:26:e1:b3:55:79"
 )

--- a/server/handlers/auth/key_check.go
+++ b/server/handlers/auth/key_check.go
@@ -87,8 +87,6 @@ func (k *KeyCheck) InDatabase(ctx context.Context) error {
 	default:
 		return err
 	}
-
-	return nil
 }
 
 // AddKey adds an account key into Triton, converting the passed in KeyPair into

--- a/server/handlers/auth/keypair.go
+++ b/server/handlers/auth/keypair.go
@@ -76,7 +76,9 @@ func (kp *KeyPair) genPrivateKeyPEM() error {
 	if err := pem.Encode(privatePEM, privatePEMBlock); err != nil {
 		return err
 	}
-	privatePEM.Flush()
+	if err := privatePEM.Flush(); err != nil {
+		return err
+	}
 
 	kp.privateKeyPEM = fmt.Sprintf("%s", privateKeyBuff)
 

--- a/server/handlers/auth/session.go
+++ b/server/handlers/auth/session.go
@@ -25,10 +25,16 @@ type Session struct {
 // NewSession constructs and returns a new Session by parsing the HTTP request,
 // validating and pulling out authentication headers.
 func NewSession(req *http.Request) (*Session, error) {
-	if devMode := os.Getenv("TSG_DEV_MODE"); devMode == "true" {
+	if devMode := os.Getenv("TSG_DEV_MODE"); devMode != "" {
+		log.Debug().
+			Str("account_id", testAccountID).
+			Str("fingerprint", testFingerprint).
+			Msg("auth: skipping authentication and using seeded defaults")
+
 		return &Session{
-			AccountID: testAccountID,
-			devMode:   true,
+			AccountID:   testAccountID,
+			Fingerprint: testFingerprint,
+			devMode:     true,
 		}, nil
 	}
 
@@ -42,10 +48,14 @@ func NewSession(req *http.Request) (*Session, error) {
 	}, nil
 }
 
+func (s *Session) IsDevMode() bool {
+	return s.devMode
+}
+
 // IsAuthenticated represents whatever it means for an authSession to be deemed
 // authenticated.
-func (a *Session) IsAuthenticated() bool {
-	return a.AccountID != "" && a.Fingerprint != ""
+func (s *Session) IsAuthenticated() bool {
+	return s.AccountID != "" && s.Fingerprint != ""
 }
 
 // EnsureAccount ensures that a Triton account is authentic and an account has

--- a/templates/instance.go
+++ b/templates/instance.go
@@ -30,6 +30,13 @@ type InstanceTemplate struct {
 	Tags               map[string]string `json:"tags"`
 }
 
+func (t *InstanceTemplate) ShortID() string {
+	if t.ID == "" {
+		return ""
+	}
+	return t.ID[:8]
+}
+
 func Get(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	session := handlers.GetAuthSession(ctx)

--- a/templates/instance_test.go
+++ b/templates/instance_test.go
@@ -14,9 +14,18 @@ import (
 	"github.com/joyent/triton-service-groups/server"
 	"github.com/joyent/triton-service-groups/server/handlers"
 	"github.com/joyent/triton-service-groups/server/router"
+	"github.com/joyent/triton-service-groups/templates"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestShortID(t *testing.T) {
+	tmpl := &templates_v1.InstanceTemplate{}
+	assert.Empty(t, tmpl.ShortID())
+
+	tmpl.ID = "f5435e8b-70b8-4e4d-8c59-1dbe5d100b5b"
+	assert.Equal(t, "f5435e8b", tmpl.ShortID())
+}
 
 // TODO: We should refactor how/where our database initializes so we can half
 // bootstrap the application from our tests with a simple one-liner.

--- a/testutils/db.go
+++ b/testutils/db.go
@@ -32,6 +32,8 @@ func NewTestDB() (*TestDB, error) {
 }
 
 // Clear clears out all active tables used during automated testing.
+//
+// TODO(justinwr): make this a loop over the tables instead
 func (db *TestDB) Clear(t *testing.T) {
 	_, err := db.Conn.Exec(`DELETE FROM tsg_groups`)
 	if err != nil {


### PR DESCRIPTION
This includes a laundry list of bug fixes that came up after merging #38.

- Fix `make default`
- Call `Template.ShortID` func when creating a Group name.
- Ensure that `TSG_DEV_MODE` is documented and functions properly.
- Ensure that whitelisting is documented.
- Blank UUIDs could not be searched properly by `Store.Exists` funcs.
- Update UUIDs properly when they're empty strings.
- Fix borked tests.