### PR TITLE
Fix critical issues with auth

### DIFF
--- a/accounts/account.go
+++ b/accounts/account.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx"
-	"github.com/jackc/pgx/pgtype"
 	"github.com/pkg/errors"
 )
 
@@ -72,31 +71,38 @@ func (a *Account) Save(ctx context.Context) error {
 		return ErrMissingID
 	}
 
-	query := `
+	updatedAt := time.Now()
+
+	if a.KeyID == "" {
+		query := `
+UPDATE tsg_accounts SET (account_name, triton_uuid, updated_at) = ($2, $3, $4)
+WHERE id = $1;
+`
+		_, err := a.store.pool.ExecEx(ctx, query, nil,
+			a.ID,
+			a.AccountName,
+			a.TritonUUID,
+			updatedAt,
+		)
+		if err != nil {
+			return errors.Wrap(err, "failed to save account with key")
+		}
+	} else {
+
+		query := `
 UPDATE tsg_accounts SET (account_name, triton_uuid, key_id, updated_at) = ($2, $3, $4, $5)
 WHERE id = $1;
 `
-	updatedAt := time.Now()
-
-	keyID := new(pgtype.UUID)
-	if a.KeyID == "" {
-		keyID.Status = pgtype.Null
-	} else {
-		keyID.Status = pgtype.Present
-		if err := keyID.Set(a.KeyID); err != nil {
-			return errors.Wrap(err, "failed to parse KeyID")
+		_, err := a.store.pool.ExecEx(ctx, query, nil,
+			a.ID,
+			a.AccountName,
+			a.TritonUUID,
+			a.KeyID,
+			updatedAt,
+		)
+		if err != nil {
+			return errors.Wrap(err, "failed to save account with key")
 		}
-	}
-
-	_, err := a.store.pool.ExecEx(ctx, query, nil,
-		a.ID,
-		a.AccountName,
-		a.TritonUUID,
-		keyID,
-		updatedAt,
-	)
-	if err != nil {
-		return errors.Wrap(err, "failed to save account")
 	}
 
 	a.UpdatedAt = updatedAt
@@ -151,8 +157,8 @@ func (a *Account) GetTritonCredential(ctx context.Context) (*TritonCredential, e
 	var credential *TritonCredential
 
 	query := `
-SELECT account_name, key_id, material FROM tsg_accounts, tsg_keys 
-WHERE tsg_accounts.key_id = tsg_keys.id 
+SELECT account_name, key_id, material FROM tsg_accounts, tsg_keys
+WHERE tsg_accounts.key_id = tsg_keys.id
 AND account_name = $1
 AND archived = false;
 `

--- a/accounts/account_test.go
+++ b/accounts/account_test.go
@@ -145,6 +145,7 @@ func TestSave(t *testing.T) {
 		key.Name = "testkey"
 		key.Fingerprint = "blahblahblah"
 		key.Material = "blahblahblah"
+		key.AccountID = account.ID
 
 		err = key.Insert(context.Background())
 		require.NoError(t, err)

--- a/dev/setup_db.sh
+++ b/dev/setup_db.sh
@@ -20,6 +20,7 @@ id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 name STRING NOT NULL,
 fingerprint STRING,
 material TEXT,
+account_id UUID,
 created_at TIMESTAMPTZ NOT NULL,
 updated_at TIMESTAMPTZ NOT NULL,
 archived BOOL DEFAULT false);"

--- a/keys/key_test.go
+++ b/keys/key_test.go
@@ -49,9 +49,12 @@ func TestInsert(t *testing.T) {
 	key := keys.New(store)
 	require.NotNil(t, key)
 
+	accountID := "d255305d-aa60-49bc-acc2-3713cf0beb1c"
+
 	key.Name = "TSG_Management"
 	key.Fingerprint = "12:23:34:45:56:67:78:89:90:0A:AB:BC:CD:DE:AD:01"
 	key.Material = "this is key material"
+	key.AccountID = accountID
 
 	err = key.Insert(context.Background())
 	require.NoError(t, err)
@@ -60,6 +63,7 @@ func TestInsert(t *testing.T) {
 	assert.Equal(t, key.Name, "TSG_Management")
 	assert.Equal(t, key.Fingerprint, "12:23:34:45:56:67:78:89:90:0A:AB:BC:CD:DE:AD:01")
 	assert.Equal(t, key.Material, "this is key material")
+	assert.Equal(t, key.AccountID, accountID)
 	assert.False(t, key.Archived)
 	assert.NotZero(t, key.CreatedAt)
 	assert.NotZero(t, key.UpdatedAt)
@@ -85,9 +89,12 @@ func TestSave(t *testing.T) {
 	key := keys.New(store)
 	require.NotNil(t, key)
 
+	accountID := "d255305d-aa60-49bc-acc2-3713cf0beb1c"
+
 	key.Name = "TSG_Management"
 	key.Fingerprint = "12:23:34:45:56:67:78:89:90:0A:AB:BC:CD:DE:AD:01"
 	key.Material = "this is key material"
+	key.AccountID = accountID
 
 	err = key.Insert(context.Background())
 	require.NoError(t, err)
@@ -125,9 +132,12 @@ func TestExists(t *testing.T) {
 	store := keys.NewStore(db.Conn)
 	require.NotNil(t, store)
 
+	accountID := "d255305d-aa60-49bc-acc2-3713cf0beb1c"
+
 	created := keys.New(store)
 	require.NotNil(t, created)
 	created.Name = "firstcreate"
+	created.AccountID = accountID
 	created.Insert(context.Background())
 
 	newKey := keys.New(store)
@@ -154,6 +164,7 @@ func TestExists(t *testing.T) {
 		assert.False(t, exists)
 	}
 
+	key.AccountID = accountID
 	err = key.Insert(context.Background())
 	require.NoError(t, err)
 

--- a/keys/store.go
+++ b/keys/store.go
@@ -59,7 +59,7 @@ WHERE id = $1 AND archived = false;
 }
 
 // FindByName finds an account by a specific account_name.
-func (s *Store) FindByName(ctx context.Context, keyName string) (*Key, error) {
+func (s *Store) FindByName(ctx context.Context, keyName string, accountID string) (*Key, error) {
 	var (
 		id          pgtype.UUID
 		name        string
@@ -72,9 +72,9 @@ func (s *Store) FindByName(ctx context.Context, keyName string) (*Key, error) {
 	query := `
 SELECT id, name, fingerprint, material, created_at, updated_at
 FROM tsg_keys
-WHERE name = $1 AND archived = false;
+WHERE name = $1 AND account_id = $2 AND archived = false;
 `
-	err := s.pool.QueryRowEx(ctx, query, nil, keyName).Scan(
+	err := s.pool.QueryRowEx(ctx, query, nil, keyName, accountID).Scan(
 		&id,
 		&name,
 		&fingerprint,
@@ -88,6 +88,7 @@ WHERE name = $1 AND archived = false;
 
 	key := New(s)
 	key.ID = convert.BytesToUUID(id.Bytes)
+	key.AccountID = accountID
 	key.Name = name
 	key.Fingerprint = fingerprint
 	key.Material = material

--- a/keys/store_test.go
+++ b/keys/store_test.go
@@ -30,9 +30,12 @@ func TestFindByID(t *testing.T) {
 	key := keys.New(store)
 	require.NotNil(t, key)
 
+	accountID := "d255305d-aa60-49bc-acc2-3713cf0beb1c"
+
 	key.Name = "TSG_Management"
 	key.Fingerprint = "12:23:34:45:56:67:78:89:90:0A:AB:BC:CD:DE:AD:01"
 	key.Material = "this is key material"
+	key.AccountID = accountID
 
 	err = key.Insert(context.Background())
 	require.NoError(t, err)
@@ -69,22 +72,26 @@ func TestFindByName(t *testing.T) {
 	key := keys.New(store)
 	require.NotNil(t, key)
 
+	accountID := "d255305d-aa60-49bc-acc2-3713cf0beb1c"
+
 	key.Name = "TSG_Management"
 	key.Fingerprint = "12:23:34:45:56:67:78:89:90:0A:AB:BC:CD:DE:AD:01"
 	key.Material = "this is key material"
+	key.AccountID = accountID
 
 	err = key.Insert(context.Background())
 	require.NoError(t, err)
 
 	require.NotZero(t, key.ID)
 
-	found, err := store.FindByName(context.Background(), key.Name)
+	found, err := store.FindByName(context.Background(), key.Name, accountID)
 	require.NoError(t, err)
 
 	assert.Equal(t, key.ID, found.ID)
 	assert.Equal(t, key.Name, found.Name)
 	assert.Equal(t, key.Fingerprint, found.Fingerprint)
 	assert.Equal(t, key.Material, found.Material)
+	assert.Equal(t, key.AccountID, found.AccountID)
 	assert.Equal(t, key.CreatedAt, found.CreatedAt)
 	assert.Equal(t, key.UpdatedAt, found.UpdatedAt)
 }

--- a/server/handlers/auth/key_check.go
+++ b/server/handlers/auth/key_check.go
@@ -118,6 +118,7 @@ func (k *KeyCheck) InsertKey(ctx context.Context, keypair *KeyPair) error {
 	key.Name = defaultKeyName
 	key.Fingerprint = keypair.FingerprintMD5
 	key.Material = keypair.PublicKeyBase64()
+	key.AccountID = k.account.ID
 
 	if err := key.Insert(ctx); err != nil {
 		return errors.Wrap(err, "failed to store account key")


### PR DESCRIPTION
More bug patches post-auth. 

This fixes an on-going issue where `Account.KeyID` is not being set properly when `KeyID` is null. I've pulled the queries apart so one either sets the `KeyID` when it is found on the `Account` and one query when it doesn't need to.

Also, fix a critical issue where keys that were just created weren't being queried back out of the system and set on the Account properly.