### PR TITLE
Fix creating Groups and Orchestration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -174,6 +174,7 @@
   version = "v3.1.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/joyent/triton-go"
   packages = [
     ".",
@@ -182,8 +183,7 @@
     "client",
     "errors"
   ]
-  revision = "f9375d2183ed70c9ca96e15e7a6869e0cea77e1f"
-  version = "1.2.0"
+  revision = "f4aff0b11754cbda33488a5b744c842ba961a218"
 
 [[projects]]
   branch = "master"
@@ -394,6 +394,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fbeb83e7ced64bd017cbfbe9043e00032ab1c0720c64aeeea8c991d44a97ea05"
+  inputs-digest = "1d5c2a84d2bde77acde9d5138c50a3f646822955f372e66558722aa59604014d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -41,3 +41,7 @@ required = ["golang.org/x/crypto/blake2b", "golang.org/x/sys/unix", "golang.org/
 [[constraint]]
   name = "github.com/hashicorp/nomad"
   branch = "master"
+
+[[constraint]]
+  name = "github.com/joyent/triton-go"
+  branch = "master"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ TSG_GOPS_PORT=9090
 TSG_PPROF_ENABLE=true
 TSG_PPROF_BIND=127.0.0.1
 TSG_PPROF_PORT=9191
+TSG_NOMAD_URL=127.0.0.1
+TSG_NOMAD_PORT=4646
+TSG_TRITON_DC=us-east-1
+TSG_TRITON_URL=https://us-east-1.api.joyent.com
 ```
 
 ## Configuration
@@ -54,19 +58,20 @@ TSG_PPROF_PORT=9191
 [log]
 level = "INFO"
 
-[postgresql]
+[crdb]
 database = "triton"
 host = "127.0.0.1"
 port = 26257
 password = ""
 user = "root"
 
-[run]
+[agent]
 log-format = "auto"
 
 [http]
 bind = "127.0.0.1"
 port = 3000
+dc = "us-east-1"
 
 [gops]
 enable = true
@@ -77,4 +82,12 @@ port = 9191
 enable = true
 bind = "127.0.0.1"
 port = 9090
+
+[nomad]
+url = "127.0.0.1"
+port = 4646
+
+[triton]
+dc = "us-east-1"
+url = "https://us-east-1.api.joyent.com"
 ```

--- a/accounts/account.go
+++ b/accounts/account.go
@@ -170,9 +170,10 @@ WHERE (id = $1 OR account_name = $2) AND archived = false;
 	}
 }
 
-// Based on an existing account, we want to get the TritonCredential. If the account
-// is found, then we will get the KeyID and KeyMaterial for the TSG Management key
-// of that account. If we do not find any credentials, we return an error.
+// GetTritonCredential gets Triton credentials from an existing Account. If the
+// account is found, then we will get the KeyID and KeyMaterial for the TSG
+// Management key of that account. If we do not find any credentials, we return
+// an error.
 func (a *Account) GetTritonCredential(ctx context.Context) (*TritonCredential, error) {
 	if a.AccountName == "" && a.ID == "" {
 		return nil, ErrExists
@@ -189,9 +190,11 @@ AND archived = false;
 	err := a.store.pool.QueryRowEx(ctx, query, nil,
 		a.ID,
 		a.AccountName,
-	).Scan(credential.AccountName,
+	).Scan(
+		credential.AccountName,
 		credential.KeyID,
-		credential.KeyMaterial)
+		credential.KeyMaterial,
+	)
 	switch err {
 	case nil:
 		return credential, nil

--- a/config/config.go
+++ b/config/config.go
@@ -28,10 +28,11 @@ type Agent struct {
 }
 
 type HTTPServer struct {
-	Bind   string
-	Port   uint16
-	Logger zerolog.Logger
-	DC     string
+	Bind      string
+	Port      uint16
+	Logger    zerolog.Logger
+	DC        string
+	TritonURL string
 }
 
 type PGXLogger struct {
@@ -110,8 +111,13 @@ func NewDefault() (cfg *Config, err error) {
 		}
 
 		httpServerConfig.DC = "us-east-1"
-		if dc := viper.GetString(KeyHTTPServerDC); dc != "" {
+		if dc := viper.GetString(KeyTritonDC); dc != "" {
 			httpServerConfig.DC = dc
+		}
+
+		httpServerConfig.TritonURL = "https://us-east-1.api.joyent.com"
+		if url := viper.GetString(KeyTritonURL); url != "" {
+			httpServerConfig.TritonURL = url
 		}
 	}
 

--- a/config/consts.go
+++ b/config/consts.go
@@ -29,7 +29,9 @@ const (
 
 	KeyHTTPServerBind = "http.bind"
 	KeyHTTPServerPort = "http.port"
-	KeyHTTPServerDC   = "http.dc"
+
+	KeyTritonDC  = "triton.dc"
+	KeyTritonURL = "triton.url"
 
 	KeyNomadURL  = "nomad.url"
 	KeyNomadPort = "nomad.port"

--- a/groups/orchestrator.go
+++ b/groups/orchestrator.go
@@ -188,6 +188,8 @@ func prepareJob(ctx context.Context, t *templates_v1.InstanceTemplate, group *Se
 }
 
 func (j *OrchestratorJob) getTritonAccountDetails(ctx context.Context) error {
+	session := handlers.GetAuthSession(ctx)
+
 	db, ok := handlers.GetDBPool(ctx)
 	if !ok {
 		log.Fatal().Err(handlers.ErrNoConnPool)
@@ -204,7 +206,7 @@ func (j *OrchestratorJob) getTritonAccountDetails(ctx context.Context) error {
 	j.TritonKeyMaterial = credential.KeyMaterial
 	j.TritonAccount = credential.AccountName
 	j.TritonKeyID = credential.KeyID
-	j.TritonURL = "" //ToDo - this will need set from the work Justin is doing
+	j.TritonURL = session.TritonURL
 
 	return nil
 }

--- a/groups/orchestrator.go
+++ b/groups/orchestrator.go
@@ -140,7 +140,7 @@ func deregisterJob(ctx context.Context, jobID string) (bool, error) {
 func registerJob(ctx context.Context, job *nomad.Job) (bool, error) {
 	client, ok := handlers.GetNomadClient(ctx)
 	if !ok {
-		log.Fatal().Err(handlers.ErrNoNomadClient)
+		log.Error().Err(handlers.ErrNoNomadClient)
 		return false, handlers.ErrNoNomadClient
 	}
 

--- a/server/handlers/auth.go
+++ b/server/handlers/auth.go
@@ -13,18 +13,20 @@ import (
 // authHandler encapsulates the authentication HTTP handler itself. We pipe all
 // active HTTP requests through this object's ServeHTTP method.
 type authHandler struct {
-	pool    *pgx.ConnPool
-	handler http.Handler
-	dc      string
+	pool      *pgx.ConnPool
+	handler   http.Handler
+	dc        string
+	tritonURL string
 }
 
 // AuthHandler constructs and returns the HTTP handler object responsible for
 // authenticating a request. This accepts a chain of HTTP handlers.
-func AuthHandler(pool *pgx.ConnPool, dc string, handler http.Handler) authHandler {
+func AuthHandler(pool *pgx.ConnPool, dc string, url string, handler http.Handler) authHandler {
 	return authHandler{
-		pool:    pool,
-		handler: handler,
-		dc:      dc,
+		pool:      pool,
+		handler:   handler,
+		dc:        dc,
+		tritonURL: url,
 	}
 }
 
@@ -75,6 +77,7 @@ func (a authHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	session.Datacenter = a.dc
+	session.TritonURL = a.tritonURL
 
 	ctx = context.WithValue(ctx, authKey, session)
 	a.handler.ServeHTTP(w, req.WithContext(ctx))

--- a/server/handlers/auth/account_check.go
+++ b/server/handlers/auth/account_check.go
@@ -52,6 +52,9 @@ func (ac *AccountCheck) OnTriton(ctx context.Context) error {
 
 	acct, err := a.Get(ctx, &account.GetInput{})
 	if err != nil {
+		log.Debug().
+			Str("account_name", ac.ParsedRequest.AccountName).
+			Msg("failed to get account")
 		return errors.Wrap(err, "failed to get account")
 	}
 

--- a/server/handlers/auth/session.go
+++ b/server/handlers/auth/session.go
@@ -19,6 +19,7 @@ type Session struct {
 	AccountID   string
 	Fingerprint string
 	Datacenter  string
+	TritonURL   string
 
 	devMode bool
 }

--- a/server/handlers/context.go
+++ b/server/handlers/context.go
@@ -58,5 +58,6 @@ func ContextHandler(pool *pgx.ConnPool, nomad *nomad.Client, h http.Handler) *co
 
 func (h *contextHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	ctx := context.WithValue(req.Context(), dbKeyName, dbValue{h.pool})
+	ctx = context.WithValue(ctx, nomadKeyName, nomadValue{h.nomad})
 	h.handler.ServeHTTP(w, req.WithContext(ctx))
 }

--- a/triton-sg.toml
+++ b/triton-sg.toml
@@ -29,3 +29,7 @@ port = 9090
 [nomad]
 url = "127.0.0.1"
 port = 4646
+
+[triton]
+dc = "us-east-1"
+url = "https://us-east-1.api.joyent.com"

--- a/vendor/github.com/joyent/triton-go/CHANGELOG.md
+++ b/vendor/github.com/joyent/triton-go/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- identity/roles: Add support for SetRoleTags [#112]
+
 ## 1.2.0 (March 20 2018)
 
 - compute/instance: Instance Deletion status now included in the GET instance response [#138]

--- a/vendor/github.com/joyent/triton-go/client/client.go
+++ b/vendor/github.com/joyent/triton-go/client/client.go
@@ -181,7 +181,7 @@ func (c *Client) overrideHeader(req *http.Request) {
 	if c.RequestHeader != nil {
 		for k, vs := range *c.RequestHeader {
 			for _, v := range vs {
-				req.Header.Add(k, v)
+				req.Header.Set(k, v)
 			}
 		}
 	}

--- a/vendor/github.com/joyent/triton-go/compute/client_test.go
+++ b/vendor/github.com/joyent/triton-go/compute/client_test.go
@@ -56,15 +56,24 @@ func TestSetHeader(t *testing.T) {
 
 func overrideHeaderTest(t *testing.T) func(req *http.Request) (*http.Response, error) {
 	return func(req *http.Request) (*http.Response, error) {
+		// test existence of custom headers at all
 		if req.Header.Get(testHeaderName) == "" {
-			t.Errorf("Request header should contain '%s'", testHeaderName)
+			t.Errorf("request header should contain '%s'", testHeaderName)
 		}
+
 		testHeader := strings.Join(req.Header[testHeaderName], ",")
-		if !strings.Contains(testHeader, testHeaderVal1) {
-			t.Errorf("Request header should contain '%s': got '%s'", testHeaderVal1, testHeader)
+
+		// test length of headers
+		if size := len(req.Header[testHeaderName]); size != 1 {
+			t.Errorf("request header length is not one: got %q", testHeader)
 		}
+		// test override of initial header
+		if strings.Contains(testHeader, testHeaderVal1) {
+			t.Errorf("request header should not contain %q: got %q", testHeaderVal1, testHeader)
+		}
+		// test that final header is the one that is set
 		if !strings.Contains(testHeader, testHeaderVal2) {
-			t.Errorf("Request header should contain '%s': got '%s'", testHeaderVal2, testHeader)
+			t.Errorf("request header should contain %q: got %q", testHeaderVal2, testHeader)
 		}
 
 		header := http.Header{}

--- a/vendor/github.com/joyent/triton-go/identity/roles_test.go
+++ b/vendor/github.com/joyent/triton-go/identity/roles_test.go
@@ -11,25 +11,278 @@ package identity_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"path"
 	"strings"
 	"testing"
+	"time"
 
+	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/identity"
 	"github.com/joyent/triton-go/testutils"
 )
 
+const fakeRoleID = "e53b8fec-e661-4ded-a21e-959c9ba08cb2"
+
 var (
-	fakeRoleId          = "1234562335"
-	listRolesErrorType  = errors.New("unable to list roles")
-	getRoleErrorType    = errors.New("unable to get role")
-	deleteRoleErrorType = errors.New("unable to delete role")
-	createRoleErrorType = errors.New("unable to create role")
-	updateRoleErrorType = errors.New("unable to update role")
+	listRolesErrorType   = errors.New("unable to list roles")
+	getRoleErrorType     = errors.New("unable to get role")
+	deleteRoleErrorType  = errors.New("unable to delete role")
+	createRoleErrorType  = errors.New("unable to create role")
+	updateRoleErrorType  = errors.New("unable to update role")
+	setRoleTagsErrorType = errors.New("unable to set role tags")
+	getRoleTagsErrorType = errors.New("unable to get role tags")
 )
 
+func TestAccIdentity_SetRoleTags(t *testing.T) {
+	testRoleName := testutils.RandPrefixString("TestAccSetRoleTags", 32)
+
+	// Holds newly created role.
+	var newRole *identity.Role
+
+	testutils.AccTest(t, testutils.TestCase{
+		Steps: []testutils.Step{
+			&testutils.StepClient{
+				StateBagKey: "identity",
+				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
+					return identity.NewClient(config)
+				},
+			},
+			&testutils.StepAPICall{
+				StateBagKey: "identity",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.CreateRoleInput{
+						Name: testRoleName,
+					}
+					role, err := c.Roles().Create(ctx, input)
+					newRole = role
+
+					// Allow a few seconds for the new role
+					// to propagate within CloudAPI.
+					time.Sleep(5 * time.Second)
+
+					return role, err
+				},
+				CleanupFunc: func(client interface{}, callState interface{}) {
+					role, roleOk := callState.(*identity.Role)
+					if !roleOk {
+						log.Println("Expected state to include role1")
+						return
+					}
+
+					if role.Name != testRoleName {
+						log.Printf("Expected role name to be %q, got %q\n",
+							testRoleName, role.Name)
+						return
+					}
+
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.DeleteRoleInput{
+						RoleID: role.ID,
+					}
+					err := c.Roles().Delete(ctx, input)
+					if err != nil {
+						log.Printf("Could not delete role %q: %v\n", role.ID, err)
+					}
+				},
+			},
+			&testutils.StepAPICall{
+				StateBagKey: "setRoleTags",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.SetRoleTagsInput{
+						ResourceType: "roles",
+						ResourceID:   newRole.ID,
+						RoleTags: []string{
+							newRole.Name,
+						},
+					}
+					return c.Roles().SetRoleTags(ctx, input)
+				},
+			},
+			&testutils.StepAssertFunc{
+				AssertFunc: func(state testutils.TritonStateBag) error {
+					roleTagsRaw, found := state.GetOk("setRoleTags")
+					if !found {
+						return fmt.Errorf("State key %q not found", "setRoleTags")
+					}
+
+					roleTags, roleTagsOk := roleTagsRaw.(*identity.RoleTags)
+					if !roleTagsOk {
+						return errors.New("Expected state to include role tags")
+					}
+
+					actual := roleTags.RoleTags[0]
+
+					if actual != testRoleName {
+						return fmt.Errorf("Expected role tags to contain %q, got %q",
+							testRoleName, actual)
+					}
+
+					return nil
+
+				},
+			},
+			&testutils.StepAPICall{
+				ErrorKey: "setRoleTagsError",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.GetRoleTagsInput{
+						ResourceType: "roles",
+						ResourceID:   "Bad-Role-Resource-ID",
+					}
+					return c.Roles().GetRoleTags(ctx, input)
+				},
+			},
+			&testutils.StepAssertTritonError{
+				ErrorKey: "setRoleTagsError",
+				Code:     "ResourceNotFound",
+			},
+		},
+	})
+}
+
+func TestAccIdentity_GetRoleTags(t *testing.T) {
+	testRoleName := testutils.RandPrefixString("TestAccGetRoleTags", 32)
+
+	// Holds newly created role.
+	var newRole *identity.Role
+
+	testutils.AccTest(t, testutils.TestCase{
+		Steps: []testutils.Step{
+			&testutils.StepClient{
+				StateBagKey: "identity",
+				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
+					return identity.NewClient(config)
+				},
+			},
+			&testutils.StepAPICall{
+				StateBagKey: "identity",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.CreateRoleInput{
+						Name: testRoleName,
+					}
+					role, err := c.Roles().Create(ctx, input)
+					newRole = role
+
+					// Allow a few seconds for the new role
+					// to propagate within CloudAPI.
+					time.Sleep(5 * time.Second)
+
+					return role, err
+				},
+				CleanupFunc: func(client interface{}, callState interface{}) {
+					role, roleOk := callState.(*identity.Role)
+					if !roleOk {
+						log.Println("Expected state to include role1")
+						return
+					}
+
+					if role.Name != testRoleName {
+						log.Printf("Expected role name to be %q, got %q\n",
+							testRoleName, role.Name)
+						return
+					}
+
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.DeleteRoleInput{
+						RoleID: role.ID,
+					}
+					err := c.Roles().Delete(ctx, input)
+					if err != nil {
+						log.Printf("Could not delete role %q: %v\n", role.ID, err)
+					}
+				},
+			},
+			&testutils.StepAPICall{
+				StateBagKey: "getRoleTags",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					setInput := &identity.SetRoleTagsInput{
+						ResourceType: "roles",
+						ResourceID:   newRole.ID,
+						RoleTags: []string{
+							newRole.Name,
+						},
+					}
+					_, err := c.Roles().SetRoleTags(ctx, setInput)
+					if err != nil {
+						return nil, err
+					}
+
+					// Allow a few seconds for the new role tag
+					// to propagate within CloudAPI.
+					time.Sleep(5 * time.Second)
+
+					getInput := &identity.GetRoleTagsInput{
+						ResourceType: "roles",
+						ResourceID:   newRole.ID,
+					}
+					return c.Roles().GetRoleTags(ctx, getInput)
+				},
+			},
+			&testutils.StepAssertFunc{
+				AssertFunc: func(state testutils.TritonStateBag) error {
+					roleTagsRaw, found := state.GetOk("getRoleTags")
+					if !found {
+						return fmt.Errorf("State key %q not found", "getRoleTags")
+					}
+
+					roleTags, roleTagsOk := roleTagsRaw.(*identity.RoleTags)
+					if !roleTagsOk {
+						return errors.New("Expected state to include role tags")
+					}
+
+					actual := roleTags.RoleTags[0]
+
+					if actual != testRoleName {
+						return fmt.Errorf("Expected role tags to contain %q, got %q",
+							testRoleName, actual)
+					}
+
+					return nil
+
+				},
+			},
+			&testutils.StepAPICall{
+				ErrorKey: "getRoleTagsError",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.GetRoleTagsInput{
+						ResourceType: "roles",
+						ResourceID:   "Bad-Role-Resource-ID",
+					}
+					return c.Roles().GetRoleTags(ctx, input)
+				},
+			},
+			&testutils.StepAssertTritonError{
+				ErrorKey: "getRoleTagsError",
+				Code:     "ResourceNotFound",
+			},
+		},
+	})
+}
 func TestDeleteRole(t *testing.T) {
 	identityClient := MockIdentityClient()
 
@@ -37,12 +290,12 @@ func TestDeleteRole(t *testing.T) {
 		defer testutils.DeactivateClient()
 
 		return ic.Roles().Delete(ctx, &identity.DeleteRoleInput{
-			RoleID: fakeRoleId,
+			RoleID: fakeRoleID,
 		})
 	}
 
 	t.Run("successful", func(t *testing.T) {
-		testutils.RegisterResponder("DELETE", path.Join("/", accountUrl, "roles", fakeRoleId), deleteRoleSuccess)
+		testutils.RegisterResponder("DELETE", path.Join("/", accountUrl, "roles", fakeRoleID), deleteRoleSuccess)
 
 		err := do(context.Background(), identityClient)
 		if err != nil {
@@ -218,7 +471,7 @@ func TestGetRole(t *testing.T) {
 		defer testutils.DeactivateClient()
 
 		role, err := ic.Roles().Get(ctx, &identity.GetRoleInput{
-			RoleID: fakeRoleId,
+			RoleID: fakeRoleID,
 		})
 		if err != nil {
 			return nil, err
@@ -227,7 +480,7 @@ func TestGetRole(t *testing.T) {
 	}
 
 	t.Run("successful", func(t *testing.T) {
-		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleId), getRoleSuccess)
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleID), getRoleSuccess)
 
 		resp, err := do(context.Background(), identityClient)
 		if err != nil {
@@ -240,7 +493,7 @@ func TestGetRole(t *testing.T) {
 	})
 
 	t.Run("eof", func(t *testing.T) {
-		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleId), getRoleEmpty)
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleID), getRoleEmpty)
 
 		_, err := do(context.Background(), identityClient)
 		if err == nil {
@@ -253,7 +506,7 @@ func TestGetRole(t *testing.T) {
 	})
 
 	t.Run("bad_decode", func(t *testing.T) {
-		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleId), getRoleBadeDecode)
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleID), getRoleBadeDecode)
 
 		_, err := do(context.Background(), identityClient)
 		if err == nil {
@@ -278,6 +531,128 @@ func TestGetRole(t *testing.T) {
 
 		if !strings.Contains(err.Error(), "unable to get role") {
 			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestSetRoleTags(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) (*identity.RoleTags, error) {
+		defer testutils.DeactivateClient()
+
+		roleTags, err := ic.Roles().SetRoleTags(ctx, &identity.SetRoleTagsInput{
+			ResourceType: "roles",
+			ResourceID:   fakeRoleID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return roleTags, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("PUT", path.Join("/", accountUrl, "roles", fakeRoleID), setRoleTagsSuccess)
+
+		response, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if response == nil {
+			t.Error("expected response to be set, got nil")
+		}
+
+		actual := response.RoleTags[0]
+
+		if actual != "test-role" {
+			t.Errorf("expected role tags to contain test role, got %s", actual)
+		}
+
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("PUT", path.Join("/", accountUrl, "roles", fakeRoleID), setRoleTagsError)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "unable to set role tags") {
+			t.Errorf("expected error to equal test error, got %s", err)
+		}
+	})
+
+	t.Run("eof", func(t *testing.T) {
+		testutils.RegisterResponder("PUT", path.Join("/", accountUrl, "roles", fakeRoleID), setRoleTagsEmpty)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "EOF") {
+			t.Errorf("expected error to contain EOF, got %s", err)
+		}
+	})
+
+	t.Run("bad_decode", func(t *testing.T) {
+		testutils.RegisterResponder("PUT", path.Join("/", accountUrl, "roles", fakeRoleID), setRoleTagsBadDecode)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "invalid character") {
+			t.Errorf("expected decode to fail, got %s", err)
+		}
+	})
+}
+
+func TestGetRoleTags(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) (*identity.RoleTags, error) {
+		defer testutils.DeactivateClient()
+
+		roleTags, err := ic.Roles().GetRoleTags(ctx, &identity.GetRoleTagsInput{
+			ResourceType: "roles",
+			ResourceID:   fakeRoleID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return roleTags, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleID), getRoleTagsSuccess)
+
+		response, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actual := response.RoleTags[0]
+
+		if actual != "test-role" {
+			t.Errorf("expected role tags to contain test role, got %s", actual)
+		}
+
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleID), getRoleTagsError)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "unable to get role tags") {
+			t.Errorf("expected error to equal test error, got %s", err)
 		}
 	})
 }
@@ -465,4 +840,75 @@ func getRoleEmpty(req *http.Request) (*http.Response, error) {
 		Header:     header,
 		Body:       ioutil.NopCloser(strings.NewReader("")),
 	}, nil
+}
+
+func setRoleTagsSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`
+{
+  "name": "/testing/role/e53b8fec-e661-4ded-a21e-959c9ba08cb2",
+  "role-tag": [
+    "test-role"
+  ]
+}
+`)
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func setRoleTagsError(req *http.Request) (*http.Response, error) {
+	return nil, setRoleTagsErrorType
+}
+
+func setRoleTagsBadDecode(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`
+{
+  "name": "/testing/role/e53b8fec-e661-4ded-a21e-959c9ba08cb2",
+  "role-tag": [
+    "test-role",
+  ]
+}
+`)
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func setRoleTagsEmpty(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       http.NoBody,
+	}, nil
+}
+
+func getRoleTagsSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+	header.Add("Role-Tag", "test-role")
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       http.NoBody,
+	}, nil
+}
+
+func getRoleTagsError(req *http.Request) (*http.Response, error) {
+	return nil, getRoleTagsErrorType
 }

--- a/vendor/github.com/joyent/triton-go/version.go
+++ b/vendor/github.com/joyent/triton-go/version.go
@@ -15,14 +15,14 @@ import (
 
 // Version represents main version number of the current release
 // of the Triton-go SDK.
-const Version = "1.2.0"
+const Version = "1.3.0"
 
 // Prerelease adds a pre-release marker to the version.
 //
 // If this is "" (empty string) then it means that it is a final release.
 // Otherwise, this is a pre-release such as "dev" (in development), "beta",
 // "rc1", etc.
-var Prerelease = ""
+var Prerelease = "dev"
 
 // UserAgent returns a Triton-go characteristic string that allows the
 // network protocol peers to identify the version, release and runtime


### PR DESCRIPTION
Working through several issues while adding DC/TritonURL and testing the creation of Groups.

- Missing TritonURL when pulling credentials.
- Orchestration wasn't pulling credentials properly.
- Fixed an issue where CloudAPI was rejecting auth requests (bump to latest `triton-go`)
- Properly introduce the Nomad client into the request context.