### PR TITLE
WIP ~ Per-DC Keys and Auth configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type HTTPServer struct {
 	Logger    zerolog.Logger
 	DC        string
 	TritonURL string
+	AuthURL   string
 }
 
 type PGXLogger struct {
@@ -118,6 +119,11 @@ func NewDefault() (cfg *Config, err error) {
 		httpServerConfig.TritonURL = "https://us-east-1.api.joyent.com"
 		if url := viper.GetString(KeyTritonURL); url != "" {
 			httpServerConfig.TritonURL = url
+		}
+
+		httpServerConfig.AuthURL = "https://us-west-1.api.joyent.com"
+		if authURL := viper.GetString(KeyTritonAuthURL); authURL != "" {
+			httpServerConfig.AuthURL = authURL
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -28,12 +28,14 @@ type Agent struct {
 }
 
 type HTTPServer struct {
-	Bind      string
-	Port      uint16
-	Logger    zerolog.Logger
-	DC        string
-	TritonURL string
-	AuthURL   string
+	Bind            string
+	Port            uint16
+	Logger          zerolog.Logger
+	DC              string
+	TritonURL       string
+	AuthURL         string
+	KeyNamePrefix   string
+	EnableWhitelist bool
 }
 
 type PGXLogger struct {
@@ -97,6 +99,8 @@ func NewDefault() (cfg *Config, err error) {
 		}
 	}
 
+	viper.SetDefault(KeyTritonWhitelist, true)
+
 	httpServerConfig := HTTPServer{}
 	{
 		httpServerConfig.Logger = log.Logger.With().Str("module", "http").Logger()
@@ -121,9 +125,16 @@ func NewDefault() (cfg *Config, err error) {
 			httpServerConfig.TritonURL = url
 		}
 
-		httpServerConfig.AuthURL = "https://us-west-1.api.joyent.com"
+		httpServerConfig.AuthURL = httpServerConfig.TritonURL
 		if authURL := viper.GetString(KeyTritonAuthURL); authURL != "" {
 			httpServerConfig.AuthURL = authURL
+		}
+
+		httpServerConfig.EnableWhitelist = viper.GetBool(KeyTritonWhitelist)
+
+		httpServerConfig.KeyNamePrefix = "TSG_Management"
+		if prefix := viper.GetString(KeyTritonKeyPrefix); prefix != "" {
+			httpServerConfig.KeyNamePrefix = prefix
 		}
 	}
 

--- a/config/consts.go
+++ b/config/consts.go
@@ -30,9 +30,11 @@ const (
 	KeyHTTPServerBind = "http.bind"
 	KeyHTTPServerPort = "http.port"
 
-	KeyTritonDC      = "triton.dc"
-	KeyTritonURL     = "triton.url"
-	KeyTritonAuthURL = "triton.auth-url"
+	KeyTritonDC        = "triton.dc"
+	KeyTritonURL       = "triton.url"
+	KeyTritonAuthURL   = "triton.auth-url"
+	KeyTritonKeyPrefix = "triton.key-prefix"
+	KeyTritonWhitelist = "triton.whitelist"
 
 	KeyNomadURL  = "nomad.url"
 	KeyNomadPort = "nomad.port"

--- a/config/consts.go
+++ b/config/consts.go
@@ -30,8 +30,9 @@ const (
 	KeyHTTPServerBind = "http.bind"
 	KeyHTTPServerPort = "http.port"
 
-	KeyTritonDC  = "triton.dc"
-	KeyTritonURL = "triton.url"
+	KeyTritonDC      = "triton.dc"
+	KeyTritonURL     = "triton.url"
+	KeyTritonAuthURL = "triton.auth-url"
 
 	KeyNomadURL  = "nomad.url"
 	KeyNomadPort = "nomad.port"

--- a/server/handlers/auth.go
+++ b/server/handlers/auth.go
@@ -48,7 +48,7 @@ func GetAuthSession(ctx context.Context) *auth.Session {
 func (a authHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	session, err := auth.NewSession(req)
+	session, err := auth.NewSession(req, a.dc, a.tritonURL)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -75,9 +75,6 @@ func (a authHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, ErrFailedAuth.Error(), http.StatusUnauthorized)
 		return
 	}
-
-	session.Datacenter = a.dc
-	session.TritonURL = a.tritonURL
 
 	ctx = context.WithValue(ctx, authKey, session)
 	a.handler.ServeHTTP(w, req.WithContext(ctx))

--- a/server/handlers/auth/account_check.go
+++ b/server/handlers/auth/account_check.go
@@ -22,10 +22,10 @@ type AccountCheck struct {
 	store  *accounts.Store
 }
 
-func NewAccountCheck(req *ParsedRequest, store *accounts.Store) *AccountCheck {
+func NewAccountCheck(req *ParsedRequest, store *accounts.Store, authURL string) *AccountCheck {
 	signer := &authentication.TestSigner{}
 	config := &triton.ClientConfig{
-		TritonURL:   tritonBaseURL,
+		TritonURL:   authURL,
 		AccountName: req.AccountName,
 		Signers:     []authentication.Signer{signer},
 	}

--- a/server/handlers/auth/account_check.go
+++ b/server/handlers/auth/account_check.go
@@ -18,22 +18,24 @@ type AccountCheck struct {
 
 	TritonAccount *account.Account
 
-	config *triton.ClientConfig
-	store  *accounts.Store
+	config          *triton.ClientConfig
+	store           *accounts.Store
+	enableWhitelist bool
 }
 
-func NewAccountCheck(req *ParsedRequest, store *accounts.Store, authURL string) *AccountCheck {
+func NewAccountCheck(req *ParsedRequest, store *accounts.Store, cfg Config) *AccountCheck {
 	signer := &authentication.TestSigner{}
 	config := &triton.ClientConfig{
-		TritonURL:   authURL,
+		TritonURL:   cfg.AuthURL,
 		AccountName: req.AccountName,
 		Signers:     []authentication.Signer{signer},
 	}
 
 	return &AccountCheck{
-		ParsedRequest: req,
-		config:        config,
-		store:         store,
+		ParsedRequest:   req,
+		config:          config,
+		store:           store,
+		enableWhitelist: cfg.EnableWhitelist,
 	}
 }
 
@@ -97,7 +99,7 @@ func (ac *AccountCheck) SaveAccount(ctx context.Context) error {
 		return err
 	}
 
-	if !exists && isWhitelistOnly {
+	if !exists && ac.enableWhitelist {
 		log.Debug().
 			Str("account_name", ac.TritonAccount.Login).
 			Str("triton_uuid", ac.TritonAccount.ID).

--- a/server/handlers/auth/config.go
+++ b/server/handlers/auth/config.go
@@ -1,0 +1,29 @@
+package auth
+
+type Config struct {
+	// Name of the datacenter in which this TSG service is operating. This is
+	// used to create unique key names per-DC. The value is also available in
+	// the HTTP request Session object.
+	Datacenter string
+
+	// URL of Triton's CloudAPI in which to scale instances. This is made
+	// available within the HTTP request Session object.
+	TritonURL string
+
+	// URL of Triton's CloudAPI in which to authenticate incoming API
+	// requests. This is only used by internal auth processes. It can be set to
+	// the same CloudAPI used by TritonURL as well.
+	AuthURL string
+
+	// Prefix name used when creating a new key in Triton. This defaults to
+	// "TSG_Management" but can be configured with whatever an end user
+	// prefers. The current Datacenter is also appended to this value at
+	// runtime.
+	KeyNamePrefix string
+
+	// Enable or disable whitelisting behavior. This feature only accepts
+	// requests from user accounts that have previously been authenticated. If
+	// this is set to true than a Triton account must be manually added to the
+	// tsg_accounts table, auto account creation will be disabled.
+	EnableWhitelist bool
+}

--- a/server/handlers/auth/consts.go
+++ b/server/handlers/auth/consts.go
@@ -5,7 +5,6 @@ const (
 	matchKeyId = `keyId=\"(.*?)\"`
 
 	defaultKeyName = "TSG_Management"
-	tritonBaseURL  = "https://us-west-1.api.joyent.com/"
 
 	// NOTE: if this is set to true than a triton account must be manually added
 	// to the tsg_accounts table, auto account creation will be disabled

--- a/server/handlers/auth/consts.go
+++ b/server/handlers/auth/consts.go
@@ -4,12 +4,6 @@ const (
 	matchName  = `^[a-zA-Z][a-zA-Z0-9_\.@]+$`
 	matchKeyId = `keyId=\"(.*?)\"`
 
-	defaultKeyName = "TSG_Management"
-
-	// NOTE: if this is set to true than a triton account must be manually added
-	// to the tsg_accounts table, auto account creation will be disabled
-	isWhitelistOnly = true
-
 	testAccountID   = "6f873d02-172c-418f-8416-4da2b50d5c53"
 	testFingerprint = "5a:ce:1e:1d:b0:96:78:c6:7a:f2:f8:26:e1:b3:55:79"
 )

--- a/server/handlers/auth/errors.go
+++ b/server/handlers/auth/errors.go
@@ -10,6 +10,7 @@ var (
 	ErrParseValue    = errors.New("incorrect values parsed from keyId")
 	ErrNameLen       = errors.New("parsed name is too short")
 	ErrNameFormat    = errors.New("parsed name is not formatted properly")
+	ErrKeyConflict   = errors.New("auth: found conflicting key state")
 
 	ErrWhitelist = errors.New("service only accessible by whitelist")
 )

--- a/server/handlers/auth/key_check.go
+++ b/server/handlers/auth/key_check.go
@@ -27,10 +27,10 @@ type KeyCheck struct {
 	dc      string
 }
 
-func NewKeyCheck(req *ParsedRequest, acct *accounts.Account, store *keys.Store, dc string) *KeyCheck {
+func NewKeyCheck(req *ParsedRequest, acct *accounts.Account, store *keys.Store, dc string, authURL string) *KeyCheck {
 	signer := &authentication.TestSigner{}
 	config := &triton.ClientConfig{
-		TritonURL:   tritonBaseURL,
+		TritonURL:   authURL,
 		AccountName: req.AccountName,
 		Signers:     []authentication.Signer{signer},
 	}

--- a/server/handlers/auth/session.go
+++ b/server/handlers/auth/session.go
@@ -67,8 +67,8 @@ func (s *Session) IsAuthenticated() bool {
 // EnsureAccount ensures that a Triton account is authentic and an account has
 // been created for it within the TSG database. Returns the TSG account that was
 // either created or found.
-func (s *Session) EnsureAccount(ctx context.Context, store *accounts.Store) (*accounts.Account, error) {
-	check := NewAccountCheck(s.ParsedRequest, store)
+func (s *Session) EnsureAccount(ctx context.Context, store *accounts.Store, authURL string) (*accounts.Account, error) {
+	check := NewAccountCheck(s.ParsedRequest, store, authURL)
 
 	if err := check.OnTriton(ctx); err != nil {
 		err = errors.Wrap(err, "failed to check triton for account")
@@ -100,8 +100,8 @@ func (s *Session) EnsureAccount(ctx context.Context, store *accounts.Store) (*ac
 
 // EnsureKey checks Triton for an active TSG account key. If one cannot be found
 // than a new key is created and stored it into the TSG database.
-func (s *Session) EnsureKeys(ctx context.Context, acct *accounts.Account, store *keys.Store) error {
-	check := NewKeyCheck(s.ParsedRequest, acct, store, s.Datacenter)
+func (s *Session) EnsureKeys(ctx context.Context, acct *accounts.Account, store *keys.Store, authURL string) error {
+	check := NewKeyCheck(s.ParsedRequest, acct, store, s.Datacenter, authURL)
 
 	if err := check.OnTriton(ctx); err != nil {
 		err = errors.Wrap(err, "failed to check triton for key")

--- a/server/handlers/auth/session.go
+++ b/server/handlers/auth/session.go
@@ -26,7 +26,7 @@ type Session struct {
 
 // NewSession constructs and returns a new Session by parsing the HTTP request,
 // validating and pulling out authentication headers.
-func NewSession(req *http.Request) (*Session, error) {
+func NewSession(req *http.Request, dc string, tritonURL string) (*Session, error) {
 	if devMode := os.Getenv("TSG_DEV_MODE"); devMode != "" {
 		log.Debug().
 			Str("account_id", testAccountID).
@@ -36,6 +36,8 @@ func NewSession(req *http.Request) (*Session, error) {
 		return &Session{
 			AccountID:   testAccountID,
 			Fingerprint: testFingerprint,
+			Datacenter:  dc,
+			TritonURL:   tritonURL,
 			devMode:     true,
 		}, nil
 	}
@@ -47,6 +49,8 @@ func NewSession(req *http.Request) (*Session, error) {
 
 	return &Session{
 		ParsedRequest: parsedReq,
+		Datacenter:    dc,
+		TritonURL:     tritonURL,
 	}, nil
 }
 

--- a/server/handlers/auth/session.go
+++ b/server/handlers/auth/session.go
@@ -101,7 +101,7 @@ func (s *Session) EnsureAccount(ctx context.Context, store *accounts.Store) (*ac
 // EnsureKey checks Triton for an active TSG account key. If one cannot be found
 // than a new key is created and stored it into the TSG database.
 func (s *Session) EnsureKeys(ctx context.Context, acct *accounts.Account, store *keys.Store) error {
-	check := NewKeyCheck(s.ParsedRequest, acct, store)
+	check := NewKeyCheck(s.ParsedRequest, acct, store, s.Datacenter)
 
 	if err := check.OnTriton(ctx); err != nil {
 		err = errors.Wrap(err, "failed to check triton for key")
@@ -128,11 +128,10 @@ func (s *Session) EnsureKeys(ctx context.Context, acct *accounts.Account, store 
 				return nil
 			}
 
-			err := errors.New("auth: found conflicting key state")
 			log.Error().
 				Str("account_name", acct.AccountName).
-				Err(err)
-			return err
+				Err(ErrKeyConflict)
+			return ErrKeyConflict
 		} else {
 			keypair, err := DecodeKeyPair(check.Key.Material)
 			if err != nil {

--- a/server/handlers/errors.go
+++ b/server/handlers/errors.go
@@ -6,5 +6,8 @@ var (
 	ErrNoConnPool    = errors.New("handlers can't access database pool")
 	ErrNoNomadClient = errors.New("handlers can't access nomad client")
 	ErrFailedAuth    = errors.New("failed request authentication")
+	ErrFailedSession = errors.New("failed session authentication")
+	ErrFailedAccount = errors.New("failed account authentication")
+	ErrFailedKey     = errors.New("failed key authentication")
 	ErrNoSession     = errors.New("failed to get authenticated session")
 )

--- a/server/server.go
+++ b/server/server.go
@@ -30,6 +30,7 @@ type HTTPServer struct {
 
 	dc        string
 	tritonURL string
+	authURL   string
 	logger    zerolog.Logger
 	pool      *pgx.ConnPool
 	nomad     *nomad.Client
@@ -47,6 +48,7 @@ func New(cfg config.HTTPServer, pool *pgx.ConnPool, nomad *nomad.Client) *HTTPSe
 		Port:      cfg.Port,
 		dc:        cfg.DC,
 		tritonURL: cfg.TritonURL,
+		authURL:   cfg.AuthURL,
 		logger:    cfg.Logger,
 		pool:      pool,
 		nomad:     nomad,
@@ -63,7 +65,7 @@ func (srv *HTTPServer) setup() {
 	log.Debug().Msg("http: mounting routes as endpoints")
 
 	router := router.WithRoutes(RoutingTable)
-	authHandler := handlers.AuthHandler(srv.pool, srv.dc, srv.tritonURL, router)
+	authHandler := handlers.AuthHandler(srv.pool, srv.dc, srv.tritonURL, srv.authURL, router)
 	contextHandler := handlers.ContextHandler(srv.pool, srv.nomad, authHandler)
 	srv.Handler = ghandlers.LoggingHandler(srv.logger, contextHandler)
 

--- a/server/server.go
+++ b/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx"
 	"github.com/joyent/triton-service-groups/config"
 	"github.com/joyent/triton-service-groups/server/handlers"
+	"github.com/joyent/triton-service-groups/server/handlers/auth"
 	"github.com/joyent/triton-service-groups/server/router"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -28,12 +29,10 @@ type HTTPServer struct {
 	Bind string
 	Port uint16
 
-	dc        string
-	tritonURL string
-	authURL   string
-	logger    zerolog.Logger
-	pool      *pgx.ConnPool
-	nomad     *nomad.Client
+	logger     zerolog.Logger
+	pool       *pgx.ConnPool
+	nomad      *nomad.Client
+	authConfig auth.Config
 
 	http.Server
 }
@@ -42,16 +41,22 @@ func New(cfg config.HTTPServer, pool *pgx.ConnPool, nomad *nomad.Client) *HTTPSe
 	log.Debug().Msg("http: creating new HTTP server")
 	addr := fmt.Sprintf("%s:%d", cfg.Bind, cfg.Port)
 
+	authConfig := auth.Config{
+		Datacenter:      cfg.DC,
+		TritonURL:       cfg.TritonURL,
+		AuthURL:         cfg.AuthURL,
+		KeyNamePrefix:   cfg.KeyNamePrefix,
+		EnableWhitelist: cfg.EnableWhitelist,
+	}
+
 	return &HTTPServer{
-		Addr:      addr,
-		Bind:      cfg.Bind,
-		Port:      cfg.Port,
-		dc:        cfg.DC,
-		tritonURL: cfg.TritonURL,
-		authURL:   cfg.AuthURL,
-		logger:    cfg.Logger,
-		pool:      pool,
-		nomad:     nomad,
+		Addr:       addr,
+		Bind:       cfg.Bind,
+		Port:       cfg.Port,
+		logger:     cfg.Logger,
+		authConfig: authConfig,
+		pool:       pool,
+		nomad:      nomad,
 	}
 }
 
@@ -65,7 +70,8 @@ func (srv *HTTPServer) setup() {
 	log.Debug().Msg("http: mounting routes as endpoints")
 
 	router := router.WithRoutes(RoutingTable)
-	authHandler := handlers.AuthHandler(srv.pool, srv.dc, srv.tritonURL, srv.authURL, router)
+
+	authHandler := handlers.AuthHandler(srv.pool, srv.authConfig, router)
 	contextHandler := handlers.ContextHandler(srv.pool, srv.nomad, authHandler)
 	srv.Handler = ghandlers.LoggingHandler(srv.logger, contextHandler)
 

--- a/templates/instance_test.go
+++ b/templates/instance_test.go
@@ -22,6 +22,7 @@ import (
 const (
 	datacenter = "us-east-1"
 	tritonURL  = "https://us-east-1.api.joyent.com"
+	authURL    = "https://us-west-1.api.joyent.com"
 )
 
 func TestShortID(t *testing.T) {
@@ -72,7 +73,7 @@ func TestAcc_Get(t *testing.T) {
 	}
 
 	router := router.WithRoutes(server.RoutingTable)
-	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, router)
+	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, authURL, router)
 	contextHandler := handlers.ContextHandler(pool, nomad, authHandler)
 
 	req := httptest.NewRequest("GET", "http://example.com/v1/tsg/templates/319209784155176962", nil)
@@ -106,7 +107,7 @@ func TestAcc_GetIncorrectTemplateName(t *testing.T) {
 	}
 
 	router := router.WithRoutes(server.RoutingTable)
-	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, router)
+	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, authURL, router)
 	contextHandler := handlers.ContextHandler(pool, nomad, authHandler)
 
 	req := httptest.NewRequest("GET", "http://example.com/v1/tsg/templates/12345", nil)
@@ -136,7 +137,7 @@ func TestAcc_List(t *testing.T) {
 	}
 
 	router := router.WithRoutes(server.RoutingTable)
-	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, router)
+	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, authURL, router)
 	contextHandler := handlers.ContextHandler(pool, nomad, authHandler)
 
 	req := httptest.NewRequest("GET", "http://example.com/v1/tsg/templates", nil)
@@ -171,7 +172,7 @@ func TestAcc_Delete(t *testing.T) {
 	}
 
 	router := router.WithRoutes(server.RoutingTable)
-	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, router)
+	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, authURL, router)
 	contextHandler := handlers.ContextHandler(pool, nomad, authHandler)
 
 	req := httptest.NewRequest("DELETE", "http://example.com/v1/tsg/templates/328937419456806913", nil)
@@ -202,7 +203,7 @@ func TestAcc_DeleteNonExistantTemplate(t *testing.T) {
 	}
 
 	router := router.WithRoutes(server.RoutingTable)
-	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, router)
+	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, authURL, router)
 	contextHandler := handlers.ContextHandler(pool, nomad, authHandler)
 
 	req := httptest.NewRequest("DELETE", "http://example.com/v1/tsg/templates/1234", nil)
@@ -232,7 +233,7 @@ func TestAcc_CreateTemplate(t *testing.T) {
 	}
 
 	router := router.WithRoutes(server.RoutingTable)
-	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, router)
+	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, authURL, router)
 	contextHandler := handlers.ContextHandler(pool, nomad, authHandler)
 
 	testBody := `{

--- a/templates/instance_test.go
+++ b/templates/instance_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx"
 	"github.com/joyent/triton-service-groups/server"
 	"github.com/joyent/triton-service-groups/server/handlers"
+	"github.com/joyent/triton-service-groups/server/handlers/auth"
 	"github.com/joyent/triton-service-groups/server/router"
 	"github.com/joyent/triton-service-groups/templates"
 	"github.com/joyent/triton-service-groups/testutils"
@@ -72,8 +73,14 @@ func TestAcc_Get(t *testing.T) {
 		t.Error(err)
 	}
 
+	authConfig := auth.Config{
+		Datacenter: datacenter,
+		TritonURL:  tritonURL,
+		AuthURL:    authURL,
+	}
+
 	router := router.WithRoutes(server.RoutingTable)
-	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, authURL, router)
+	authHandler := handlers.AuthHandler(pool, authConfig, router)
 	contextHandler := handlers.ContextHandler(pool, nomad, authHandler)
 
 	req := httptest.NewRequest("GET", "http://example.com/v1/tsg/templates/319209784155176962", nil)
@@ -106,8 +113,14 @@ func TestAcc_GetIncorrectTemplateName(t *testing.T) {
 		t.Error(err)
 	}
 
+	authConfig := auth.Config{
+		Datacenter: datacenter,
+		TritonURL:  tritonURL,
+		AuthURL:    authURL,
+	}
+
 	router := router.WithRoutes(server.RoutingTable)
-	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, authURL, router)
+	authHandler := handlers.AuthHandler(pool, authConfig, router)
 	contextHandler := handlers.ContextHandler(pool, nomad, authHandler)
 
 	req := httptest.NewRequest("GET", "http://example.com/v1/tsg/templates/12345", nil)
@@ -136,8 +149,14 @@ func TestAcc_List(t *testing.T) {
 		t.Error(err)
 	}
 
+	authConfig := auth.Config{
+		Datacenter: datacenter,
+		TritonURL:  tritonURL,
+		AuthURL:    authURL,
+	}
+
 	router := router.WithRoutes(server.RoutingTable)
-	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, authURL, router)
+	authHandler := handlers.AuthHandler(pool, authConfig, router)
 	contextHandler := handlers.ContextHandler(pool, nomad, authHandler)
 
 	req := httptest.NewRequest("GET", "http://example.com/v1/tsg/templates", nil)
@@ -171,8 +190,14 @@ func TestAcc_Delete(t *testing.T) {
 		t.Error(err)
 	}
 
+	authConfig := auth.Config{
+		Datacenter: datacenter,
+		TritonURL:  tritonURL,
+		AuthURL:    authURL,
+	}
+
 	router := router.WithRoutes(server.RoutingTable)
-	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, authURL, router)
+	authHandler := handlers.AuthHandler(pool, authConfig, router)
 	contextHandler := handlers.ContextHandler(pool, nomad, authHandler)
 
 	req := httptest.NewRequest("DELETE", "http://example.com/v1/tsg/templates/328937419456806913", nil)
@@ -202,8 +227,14 @@ func TestAcc_DeleteNonExistantTemplate(t *testing.T) {
 		t.Error(err)
 	}
 
+	authConfig := auth.Config{
+		Datacenter: datacenter,
+		TritonURL:  tritonURL,
+		AuthURL:    authURL,
+	}
+
 	router := router.WithRoutes(server.RoutingTable)
-	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, authURL, router)
+	authHandler := handlers.AuthHandler(pool, authConfig, router)
 	contextHandler := handlers.ContextHandler(pool, nomad, authHandler)
 
 	req := httptest.NewRequest("DELETE", "http://example.com/v1/tsg/templates/1234", nil)
@@ -232,8 +263,14 @@ func TestAcc_CreateTemplate(t *testing.T) {
 		t.Error(err)
 	}
 
+	authConfig := auth.Config{
+		Datacenter: datacenter,
+		TritonURL:  tritonURL,
+		AuthURL:    authURL,
+	}
+
 	router := router.WithRoutes(server.RoutingTable)
-	authHandler := handlers.AuthHandler(pool, datacenter, tritonURL, authURL, router)
+	authHandler := handlers.AuthHandler(pool, authConfig, router)
 	contextHandler := handlers.ContextHandler(pool, nomad, authHandler)
 
 	testBody := `{

--- a/triton-sg.toml
+++ b/triton-sg.toml
@@ -34,3 +34,7 @@ port = 4646
 dc = "us-east-1"
 url = "https://us-east-1.api.joyent.com"
 auth-url = "https://us-west-1.api.joyent.com"
+key-prefix = "TSG_Management"
+whitelist = true
+
+

--- a/triton-sg.toml
+++ b/triton-sg.toml
@@ -33,3 +33,4 @@ port = 4646
 [triton]
 dc = "us-east-1"
 url = "https://us-east-1.api.joyent.com"
+auth-url = "https://us-west-1.api.joyent.com"


### PR DESCRIPTION
In order to utilize the authentication process across different environments, we want to be able to configure some values. Things like Datacenter, TritonURL, AuthURL, KeyPrefix, and Whitelisting are all values that can be configured. Managing these became cumbersome and it was easier to add a configuration struct to handle these. This commit touches a few files but makes it easier to configure authentication for these values.

\***WIP**\* Still need to test the viability of these changes so far.