### PR TITLE
orchestrator: Adding the orchestration task constraints

### DIFF
--- a/groups/orchestrator.go
+++ b/groups/orchestrator.go
@@ -277,6 +277,14 @@ job "{{.JobName}}" {
   }
   datacenters = ["{{ .Datacenter }}"]
   group "scale" {
+	constraint {
+      distinct_hosts = true
+    }
+    constraint {
+      operator = "="
+      attribute = "${meta.role}"
+      value = "automater"
+    }
 	task "healthy" {
 	  driver = "exec"
 	  artifact {


### PR DESCRIPTION
This means that we will only run the scale commands on specific
nomad client instances