### PR TITLE
orchestrator: Change the download location of the TSG CLI binary

### DIFF
--- a/groups/orchestrator.go
+++ b/groups/orchestrator.go
@@ -273,8 +273,11 @@ job "{{.JobName}}" {
 	task "healthy" {
 	  driver = "exec"
 	  artifact {
-		source = "http://us-east.manta.joyent.com/productci/public/tsg"
-	  }
+        source = "https://github.com/joyent/tsg-cli/releases/download/v0.1.0/tsg-cli_0.1.0_linux_amd64.tar.gz"
+		options {
+          checksum = "sha256:0aa5bf0bfea4da8b4c58178e0764c0fa06ca09075df3a44ef6ed6fc11d2b74ce"
+        }
+      }
 	  config {
 		command = "tsg"
 		args = [


### PR DESCRIPTION
This will now come from github and have a checksum option to ensure
it isn't tampered with