### PR TITLE
groups: Fix. Add missing struct annotations for JSON serializer.

### DIFF
--- a/groups/groups.go
+++ b/groups/groups.go
@@ -179,9 +179,9 @@ func List(w http.ResponseWriter, r *http.Request) {
 }
 
 type ActionableInput struct {
-	InstanceCount int
-	MaxInstance   int
-	MinInstance   int
+	InstanceCount int `json:"instance_count"`
+	MaxInstance   int `json:"max_instance"`
+	MinInstance   int `json:"min_instance"`
 }
 
 func Increment(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This commit adds missing annotations for JSON serializer and thus make the JSON
in the request consistent with other JSON payload we have, plus with the common
way of how JSON is usually formatted (e.g., lower-case letters with a snake-case
style word breaking on an underscore).

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>