### PR TITLE
groups: Updating group throws 502

### DIFF
--- a/groups/groups.go
+++ b/groups/groups.go
@@ -179,9 +179,9 @@ func List(w http.ResponseWriter, r *http.Request) {
 }
 
 type ActionableInput struct {
-	InstanceCount int `json:"instance_count"`
-	MaxInstance   int `json:"max_instance"`
-	MinInstance   int `json:"min_instance"`
+	InstanceCount int `json:"instance_count"` //Number of instances to decrement by
+	MaxInstance   int `json:"max_instance"`   //Maximum number of instances allowed in group
+	MinInstance   int `json:"min_instance"`   //Minimum number of instances allowed in group
 }
 
 func Increment(w http.ResponseWriter, r *http.Request) {

--- a/groups/groups_db.go
+++ b/groups/groups_db.go
@@ -172,7 +172,7 @@ VALUES ($1, $2, $3, $4, NOW(), NOW())
 	}
 }
 
-func UpdateGroup(ctx context.Context, name string, accountID string, group *ServiceGroup) {
+func UpdateGroup(ctx context.Context, uuid string, accountID string, group *ServiceGroup) {
 	db, ok := handlers.GetDBPool(ctx)
 	if !ok {
 		log.Fatal().Err(handlers.ErrNoConnPool)
@@ -182,10 +182,10 @@ func UpdateGroup(ctx context.Context, name string, accountID string, group *Serv
 	sqlStatement := `
 UPDATE tsg_groups
 SET template_id = $3, capacity = $4, updated_at = NOW()
-WHERE name = $1 and account_id = $2
+WHERE id = $1 and account_id = $2
 `
 	_, err := db.ExecEx(ctx, sqlStatement, nil,
-		name,
+		uuid,
 		accountID,
 		group.TemplateID,
 		group.Capacity,


### PR DESCRIPTION
When we were updating a group via increment, decrement or a PUT request
we were trying to take a group UUID as the group name in the sql statement
therefore, we were not returning any rows and not actually updating
the database

Nomad was still being updated, therefore we were getting strange behaviour

i.e. We create a group with 3 instances
we add 2 via increment, the db was not updated but nomad was
when we then decremented by 1, we were passing that the group had 3 (not 5)
and nomad was then killing all but 2 nodes where it only should have
killed 1 node