### PR TITLE
orchestrator/job_name: change Job Name format

### DIFF
--- a/groups/orchestrator.go
+++ b/groups/orchestrator.go
@@ -220,12 +220,13 @@ func (j *OrchestratorJob) getTritonAccountDetails(ctx context.Context) error {
 	j.TritonKeyID = credential.KeyID
 	j.TritonURL = session.TritonURL
 
+	j.JobName = fmt.Sprintf("%s_%s", j.ServiceGroupName, account.TritonUUID)
+
 	return nil
 }
 
 func createJobDetails(template *templates_v1.InstanceTemplate, group *ServiceGroup) OrchestratorJob {
 	job := OrchestratorJob{
-		JobName:          fmt.Sprintf("%s_%s", group.GroupName, template.ShortID()),
 		DesiredCount:     group.Capacity,
 		PackageID:        template.Package,
 		ImageID:          template.ImageID,


### PR DESCRIPTION
Previously, we would make an orchestrastion job use the format of
groupname_templateID. Therefore, if the same group was used with a
different templateID, then we would effectively have 2 jobs doing a
similar thing

We would have had to somehow detect the *old* TemplateID and then drain
that job. Which wasn't working

Therefore, as we can only have 1 use of a group name per triton UUID, we
will now formulate the job name as groupname_tritonUUID.

This will mean that for the lifecycle of a job, we will have the same name
format. So even when a templateID changes, there will only be 1 instance
of a job and there is no chance of a duplicate job being created

Nomad will only allow 1 instance of a job running - so we will get an
error if this happens