### PR TITLE
groups: Ensure uniqueness for group name per account

### DIFF
--- a/dev/setup_db.sh
+++ b/dev/setup_db.sh
@@ -66,7 +66,8 @@ capacity INT NOT NULL,
 health_check_interval INT DEFAULT 300,
 created_at TIMESTAMPTZ NOT NULL,
 updated_at TIMESTAMPTZ NOT NULL,
-archived BOOL DEFAULT false);"
+archived BOOL DEFAULT false)
+UNIQUE (name, account_id);"
 
     if [ -f /dev/backup.sql ]; then
         /cockroach/cockroach.sh sql $HOSTPARAMS --database=$env < /dev/backup.sql

--- a/groups/groups.go
+++ b/groups/groups.go
@@ -69,7 +69,11 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	SaveGroup(ctx, session.AccountID, group)
+	err = SaveGroup(ctx, session.AccountID, group)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	err = SubmitOrchestratorJob(ctx, group)
 	if err != nil {
@@ -88,6 +92,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 	bytes, err := json.Marshal(com)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	writeJsonResponse(w, bytes)
@@ -103,6 +108,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	group, err := decodeResponseBodyAndValidate(body)
@@ -111,7 +117,11 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	UpdateGroup(ctx, identifier, session.AccountID, group)
+	err = UpdateGroup(ctx, identifier, session.AccountID, group)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	err = UpdateOrchestratorJob(ctx, group)
 	if err != nil {
@@ -128,6 +138,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	bytes, err := json.Marshal(com)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	writeJsonResponse(w, bytes)
@@ -148,7 +159,11 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	RemoveGroup(ctx, group.ID, session.AccountID)
+	err := RemoveGroup(ctx, group.ID, session.AccountID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	if err := DeleteOrchestratorJob(ctx, group); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -164,7 +179,6 @@ func List(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := FindGroups(ctx, session.AccountID)
 	if err != nil {
-		log.Fatal().Err(err)
 		http.NotFound(w, r)
 		return
 	}
@@ -172,6 +186,7 @@ func List(w http.ResponseWriter, r *http.Request) {
 	bytes, err := json.Marshal(rows)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	writeJsonResponse(w, bytes)
@@ -216,7 +231,11 @@ func Increment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//Update the Database and the orchestration job
-	UpdateGroup(ctx, uuid, session.AccountID, group)
+	err = UpdateGroup(ctx, uuid, session.AccountID, group)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	err = UpdateOrchestratorJob(ctx, group)
 	if err != nil {
@@ -261,7 +280,11 @@ func Decrement(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//Update the Database and the orchestration job
-	UpdateGroup(ctx, uuid, session.AccountID, group)
+	err = UpdateGroup(ctx, uuid, session.AccountID, group)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	if err := UpdateOrchestratorJob(ctx, group); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -287,19 +310,19 @@ func ListInstances(w http.ResponseWriter, r *http.Request) {
 
 	db, ok := handlers.GetDBPool(ctx)
 	if !ok {
-		log.Fatal().Err(handlers.ErrNoConnPool)
 		http.Error(w, handlers.ErrNoConnPool.Error(), http.StatusInternalServerError)
+		return
 	}
 	store := accounts.NewStore(db)
 	account, err := store.FindByID(ctx, session.AccountID)
 	if err != nil {
-		log.Error().Err(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	credential, err := account.GetTritonCredential(ctx)
 	if err != nil {
-		log.Fatal().Err(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -311,8 +334,8 @@ func ListInstances(w http.ResponseWriter, r *http.Request) {
 	signer, err := authentication.NewPrivateKeySigner(input)
 	if err != nil {
 		returnError := errors.Wrapf(err, "error Creating SSH Private Key Signer")
-		log.Fatal().Err(returnError)
 		http.Error(w, returnError.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	config := &triton.ClientConfig{
@@ -324,8 +347,8 @@ func ListInstances(w http.ResponseWriter, r *http.Request) {
 	c, err := compute.NewClient(config)
 	if err != nil {
 		returnError := errors.Wrapf(err, "error constructing ComputeClient")
-		log.Fatal().Err(returnError)
 		http.Error(w, returnError.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	params := &compute.ListInstancesInput{}
@@ -336,15 +359,15 @@ func ListInstances(w http.ResponseWriter, r *http.Request) {
 	instances, err := c.Instances().List(ctx, params)
 	if err != nil {
 		returnError := errors.Wrapf(err, "error listing instances in TSG")
-		log.Fatal().Err(returnError)
 		http.Error(w, returnError.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	bytes, err := json.Marshal(instances)
 	if err != nil {
 		returnError := errors.Wrapf(err, "error marshalling TSG instance list")
-		log.Fatal().Err(returnError)
 		http.Error(w, returnError.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	writeJsonResponse(w, bytes)

--- a/groups/groups_db.go
+++ b/groups/groups_db.go
@@ -13,13 +13,11 @@ import (
 	"github.com/jackc/pgx/pgtype"
 	"github.com/joyent/triton-service-groups/convert"
 	"github.com/joyent/triton-service-groups/server/handlers"
-	"github.com/rs/zerolog/log"
 )
 
 func FindGroups(ctx context.Context, accountID string) ([]*ServiceGroup, error) {
 	db, ok := handlers.GetDBPool(ctx)
 	if !ok {
-		log.Fatal().Err(handlers.ErrNoConnPool)
 		return nil, handlers.ErrNoConnPool
 	}
 
@@ -71,7 +69,6 @@ AND archived = false;`
 func FindGroupByID(ctx context.Context, key string, accountID string) (*ServiceGroup, bool) {
 	db, ok := handlers.GetDBPool(ctx)
 	if !ok {
-		log.Fatal().Err(handlers.ErrNoConnPool)
 		return nil, false
 	}
 
@@ -109,14 +106,13 @@ AND archived = false
 		fmt.Println("No rows were returned!")
 		return nil, false
 	default:
-		panic(err)
+		return nil, false
 	}
 }
 
 func FindGroupByName(ctx context.Context, name string, accountID string) (*ServiceGroup, bool) {
 	db, ok := handlers.GetDBPool(ctx)
 	if !ok {
-		log.Fatal().Err(handlers.ErrNoConnPool)
 		return nil, false
 	}
 
@@ -153,15 +149,14 @@ AND archived = false;
 		fmt.Println("No rows were returned!")
 		return nil, false
 	default:
-		panic(err)
+		return nil, false
 	}
 }
 
-func SaveGroup(ctx context.Context, accountID string, group *ServiceGroup) {
+func SaveGroup(ctx context.Context, accountID string, group *ServiceGroup) error {
 	db, ok := handlers.GetDBPool(ctx)
 	if !ok {
-		log.Fatal().Err(handlers.ErrNoConnPool)
-		return
+		return handlers.ErrNoConnPool
 	}
 
 	sqlStatement := `
@@ -175,15 +170,16 @@ VALUES ($1, $2, $3, $4, NOW(), NOW())
 		accountID,
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
-func UpdateGroup(ctx context.Context, uuid string, accountID string, group *ServiceGroup) {
+func UpdateGroup(ctx context.Context, uuid string, accountID string, group *ServiceGroup) error {
 	db, ok := handlers.GetDBPool(ctx)
 	if !ok {
-		log.Fatal().Err(handlers.ErrNoConnPool)
-		return
+		return handlers.ErrNoConnPool
 	}
 
 	sqlStatement := `
@@ -198,15 +194,16 @@ WHERE id = $1 and account_id = $2
 		group.Capacity,
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
-func RemoveGroup(ctx context.Context, identifier string, accountID string) {
+func RemoveGroup(ctx context.Context, identifier string, accountID string) error {
 	db, ok := handlers.GetDBPool(ctx)
 	if !ok {
-		log.Fatal().Err(handlers.ErrNoConnPool)
-		return
+		return handlers.ErrNoConnPool
 	}
 
 	sqlStatement := `
@@ -216,6 +213,8 @@ WHERE id = $1 and account_id = $2
 `
 	_, err := db.ExecEx(ctx, sqlStatement, nil, identifier, accountID)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }

--- a/groups/orchestrator.go
+++ b/groups/orchestrator.go
@@ -125,7 +125,6 @@ func DeleteOrchestratorJob(ctx context.Context, group *ServiceGroup) error {
 func deregisterJob(ctx context.Context, jobID string) (bool, error) {
 	client, ok := handlers.GetNomadClient(ctx)
 	if !ok {
-		log.Fatal().Err(handlers.ErrNoNomadClient)
 		return false, handlers.ErrNoNomadClient
 	}
 

--- a/templates/instance.go
+++ b/templates/instance.go
@@ -54,8 +54,8 @@ func Get(w http.ResponseWriter, r *http.Request) {
 
 	bytes, err := json.Marshal(template)
 	if err != nil {
-		log.Fatal().Err(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	writeJsonResponse(w, bytes)
@@ -67,18 +67,22 @@ func Create(w http.ResponseWriter, r *http.Request) {
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		log.Fatal().Err(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	var template *InstanceTemplate
 	err = json.Unmarshal(body, &template)
 	if err != nil {
-		log.Fatal().Err(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
-	SaveTemplate(ctx, session.AccountID, template)
+	err = SaveTemplate(ctx, session.AccountID, template)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	w.Header().Set("Location", path.Join(r.URL.Path, template.TemplateName))
 
@@ -90,8 +94,8 @@ func Create(w http.ResponseWriter, r *http.Request) {
 
 	bytes, err := json.Marshal(com)
 	if err != nil {
-		log.Fatal().Err(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	w.WriteHeader(http.StatusCreated)
@@ -114,7 +118,12 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	RemoveTemplate(ctx, template.ID, session.AccountID)
+	err := RemoveTemplate(ctx, template.ID, session.AccountID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -124,15 +133,14 @@ func List(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := FindTemplates(ctx, session.AccountID)
 	if err != nil {
-		log.Fatal().Err(err)
 		http.NotFound(w, r)
 		return
 	}
 
 	bytes, err := json.Marshal(rows)
 	if err != nil {
-		log.Fatal().Err(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	writeJsonResponse(w, bytes)


### PR DESCRIPTION
In order to stop an account having multiple groups of the same
name, we are going to add a unique constraint across group name
and account_id

This follows the pattern that a group is immutable for an account

You can see this in action here:

https://www.cockroachlabs.com/docs/stable/unique.html#usage-example