### PR TITLE
GET requests should not return null

### DIFF
--- a/groups/groups.go
+++ b/groups/groups.go
@@ -51,7 +51,11 @@ func Get(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 
-	writeJsonResponse(w, bytes)
+	if string(bytes) == "null" {
+		writeJsonResponse(w, []byte("{}"))
+	} else {
+		writeJsonResponse(w, bytes)
+	}
 }
 
 func Create(w http.ResponseWriter, r *http.Request) {
@@ -190,7 +194,11 @@ func List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJsonResponse(w, bytes)
+	if string(bytes) == "null" {
+		writeJsonResponse(w, []byte("[]"))
+	} else {
+		writeJsonResponse(w, bytes)
+	}
 }
 
 type ActionableInput struct {
@@ -371,7 +379,11 @@ func ListInstances(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJsonResponse(w, bytes)
+	if string(bytes) == "null" {
+		writeJsonResponse(w, []byte("[]"))
+	} else {
+		writeJsonResponse(w, bytes)
+	}
 }
 
 func writeJsonResponse(w http.ResponseWriter, bytes []byte) {

--- a/templates/instance.go
+++ b/templates/instance.go
@@ -58,7 +58,11 @@ func Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJsonResponse(w, bytes)
+	if string(bytes) == "null" {
+		writeJsonResponse(w, []byte("{}"))
+	} else {
+		writeJsonResponse(w, bytes)
+	}
 }
 
 func Create(w http.ResponseWriter, r *http.Request) {
@@ -142,7 +146,11 @@ func List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJsonResponse(w, bytes)
+	if string(bytes) == "null" {
+		writeJsonResponse(w, []byte("[]"))
+	} else {
+		writeJsonResponse(w, bytes)
+	}
 }
 
 func writeJsonResponse(w http.ResponseWriter, bytes []byte) {


### PR DESCRIPTION
On GET requests with no response, we returned null to the user
we should return valid JSON of [] or {} depending on if we are
returning a list or a single object

Fixes #70