### PR TITLE
Fix. Correctly set the `Content-Type` response header.

### DIFF
--- a/groups/groups.go
+++ b/groups/groups.go
@@ -51,11 +51,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 
-	if string(bytes) == "null" {
-		writeJsonResponse(w, []byte("{}"))
-	} else {
-		writeJsonResponse(w, bytes)
-	}
+	writeJSONResponse(w, bytes, http.StatusOK)
 }
 
 func Create(w http.ResponseWriter, r *http.Request) {
@@ -99,8 +95,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
-	writeJsonResponse(w, bytes)
+	writeJSONResponse(w, bytes, http.StatusCreated)
 }
 
 func Update(w http.ResponseWriter, r *http.Request) {
@@ -146,7 +141,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJsonResponse(w, bytes)
+	writeJSONResponse(w, bytes, http.StatusOK)
 }
 
 func Delete(w http.ResponseWriter, r *http.Request) {
@@ -188,17 +183,18 @@ func List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if rows == nil || len(rows) == 0 {
+		writeJSONResponse(w, []byte("[]"), http.StatusOK)
+		return
+	}
+
 	bytes, err := json.Marshal(rows)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	if string(bytes) == "null" {
-		writeJsonResponse(w, []byte("[]"))
-	} else {
-		writeJsonResponse(w, bytes)
-	}
+	writeJSONResponse(w, bytes, http.StatusOK)
 }
 
 type ActionableInput struct {
@@ -372,6 +368,11 @@ func ListInstances(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if instances != nil && len(instances) == 0 {
+		writeJSONResponse(w, []byte("[]"), http.StatusOK)
+		return
+	}
+
 	bytes, err := json.Marshal(instances)
 	if err != nil {
 		returnError := errors.Wrapf(err, "error marshalling TSG instance list")
@@ -379,15 +380,12 @@ func ListInstances(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if string(bytes) == "null" {
-		writeJsonResponse(w, []byte("[]"))
-	} else {
-		writeJsonResponse(w, bytes)
-	}
+	writeJSONResponse(w, bytes, http.StatusOK)
 }
 
-func writeJsonResponse(w http.ResponseWriter, bytes []byte) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+func writeJSONResponse(w http.ResponseWriter, bytes []byte, statusCode int) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(statusCode)
 	if n, err := w.Write(bytes); err != nil {
 		log.Printf("%v", err)
 	} else if n != len(bytes) {

--- a/templates/instance.go
+++ b/templates/instance.go
@@ -58,11 +58,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if string(bytes) == "null" {
-		writeJsonResponse(w, []byte("{}"))
-	} else {
-		writeJsonResponse(w, bytes)
-	}
+	writeJSONResponse(w, bytes, http.StatusOK)
 }
 
 func Create(w http.ResponseWriter, r *http.Request) {
@@ -102,8 +98,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
-	writeJsonResponse(w, bytes)
+	writeJSONResponse(w, bytes, http.StatusCreated)
 }
 
 func Delete(w http.ResponseWriter, r *http.Request) {
@@ -140,21 +135,23 @@ func List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if rows == nil || len(rows) == 0 {
+		writeJSONResponse(w, []byte("[]"), http.StatusOK)
+		return
+	}
+
 	bytes, err := json.Marshal(rows)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	if string(bytes) == "null" {
-		writeJsonResponse(w, []byte("[]"))
-	} else {
-		writeJsonResponse(w, bytes)
-	}
+	writeJSONResponse(w, bytes, http.StatusOK)
 }
 
-func writeJsonResponse(w http.ResponseWriter, bytes []byte) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+func writeJSONResponse(w http.ResponseWriter, bytes []byte, statusCode int) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(statusCode)
 	if n, err := w.Write(bytes); err != nil {
 		log.Printf("%v", err)
 	} else if n != len(bytes) {


### PR DESCRIPTION
This commit resolves an issue where setting a correct `Content-Type` header
would have no effect when the response was received by the client (a different
value (default) for the `Content-Type` would be set (e.g., `text/plain`).

The problem occurs when `WriteHeader()` is being called before any headers are
set - in which case setting headers has no effect - or after `Write()` without
any headers being set prior - in which case, the `Write()` method attempts to
detect the content type of the body by reading first 512 bytes (and for JSON
payload that would result in the MIME type being detected as plain text).

See comments from the `ResponseWriter` type:

    * https://golang.org/pkg/net/http/#ResponseWriter

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>