### PR TITLE
Fix. Prevent a template to be removed while in use by at least one group.

### DIFF
--- a/dev/setup_db.sh
+++ b/dev/setup_db.sh
@@ -55,7 +55,7 @@ userdata TEXT,
 metadata TEXT,
 tags TEXT,
 created_at TIMESTAMPTZ NOT NULL,
-archived BOOL DEFAULT false),
+archived BOOL DEFAULT false,
 UNIQUE (template_name, account_id, archived));"
 
     $SQL -d $env -e "CREATE TABLE IF NOT EXISTS tsg_groups (

--- a/templates/instance.go
+++ b/templates/instance.go
@@ -7,6 +7,7 @@ package templates_v1
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"path"
@@ -84,8 +85,6 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Location", path.Join(r.URL.Path, template.TemplateName))
-
 	com, ok := FindTemplateByName(ctx, template.TemplateName, session.AccountID)
 	if !ok {
 		http.NotFound(w, r)
@@ -98,6 +97,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Location", path.Join(r.URL.Path, template.TemplateName))
 	writeJSONResponse(w, bytes, http.StatusCreated)
 }
 
@@ -110,13 +110,25 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 
 	var template *InstanceTemplate
 
+	templateAllocated, err := CheckTemplateAllocationByID(ctx, uuid, session.AccountID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if templateAllocated {
+		http.Error(w, fmt.Sprintf("Cannot delete template %q while in use, "+
+			"must be removed from all groups first.", uuid),
+			http.StatusConflict)
+		return
+	}
+
 	template, ok := FindTemplateByID(ctx, uuid, session.AccountID)
 	if !ok {
 		http.NotFound(w, r)
 		return
 	}
 
-	err := RemoveTemplate(ctx, template.ID, session.AccountID)
+	err = RemoveTemplate(ctx, template.ID, session.AccountID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
This commit adds a new lookup functions which can be used to determine whether
there are any groups to which a particular template has been allocated. This is
then used to stop an "in-use" template from being removed.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>