### PR TITLE
Limit group capacity to a 100 compute instances.

### DIFF
--- a/groups/groups.go
+++ b/groups/groups.go
@@ -424,6 +424,14 @@ func decodeResponseBodyAndValidate(body []byte) (*ServiceGroup, error) {
 		return nil, errors.New("templateID must be a valid UUID")
 	}
 
+	if group.Capacity < 0 {
+		return nil, errors.New("group capacity cannot be a negative number")
+	}
+
+	if group.Capacity > 100 {
+		return nil, errors.New("group capacity cannot be more than 100 compute instances")
+	}
+
 	return group, nil
 }
 


### PR DESCRIPTION
This commit adds a limit of 100 compute instances per-group, and also ensures
that a negative number would not be accepted as valid capacity.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>