### PR TITLE
Fix. Handle creation of duplicate templates and groups without unique constraint.

### DIFF
--- a/dev/setup_db.sh
+++ b/dev/setup_db.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
+
 set -e
+set -o pipefail
 
 if [ -x "/cockroach/cockroach.sh" ]; then
     echo "Wait for servers to be up"
@@ -16,59 +18,100 @@ for env in triton triton_test; do
     $SQL -e "DROP DATABASE IF EXISTS ${env} CASCADE;"
     $SQL -e "CREATE DATABASE IF NOT EXISTS ${env};"
 
-    $SQL -d $env -e "CREATE TABLE IF NOT EXISTS tsg_keys (
-id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-name STRING NOT NULL,
-fingerprint STRING,
-material TEXT,
-account_id UUID,
-created_at TIMESTAMPTZ NOT NULL,
-updated_at TIMESTAMPTZ NOT NULL,
-archived BOOL DEFAULT false);"
+    cat <<'EOS' | $SQL -d $env
+CREATE TABLE IF NOT EXISTS tsg_keys (
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" STRING NOT NULL,
+    fingerprint STRING NULL,
+    material STRING NULL,
+    account_id UUID NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    archived BOOL NULL DEFAULT false,
+    CONSTRAINT "primary" PRIMARY KEY (id ASC),
+    INDEX name_idx ("name" ASC),
+    INDEX id_name_idx (id ASC, "name" ASC),
+    INDEX id_account_id_idx (id ASC, account_id ASC),
+    INDEX archived_idx (archived ASC),
+    FAMILY "primary" (id, "name", fingerprint, material, account_id, created_at, updated_at, archived)
+);
+EOS
 
-    $SQL -d $env -e "CREATE TABLE IF NOT EXISTS tsg_accounts (
-id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-account_name STRING NOT NULL,
-triton_uuid STRING,
-key_id UUID REFERENCES tsg_keys (id),
-created_at TIMESTAMPTZ NOT NULL,
-updated_at TIMESTAMPTZ NOT NULL,
-archived BOOL DEFAULT false);"
+    cat <<'EOS' | $SQL -d $env
+CREATE TABLE IF NOT EXISTS tsg_accounts (
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
+    account_name STRING NOT NULL,
+    triton_uuid STRING NULL,
+    key_id UUID NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    archived BOOL NULL DEFAULT false,
+    CONSTRAINT "primary" PRIMARY KEY (id ASC),
+    CONSTRAINT key_id_tsg_keys_id_fk FOREIGN KEY (key_id) REFERENCES tsg_keys (id),
+    INDEX key_id_tsg_keys_id_fk_idx (key_id ASC),
+    INDEX name_idx (account_name ASC),
+    INDEX id_name_idx (id ASC, account_name ASC),
+    INDEX archived_idx (archived ASC),
+    FAMILY "primary" (id, account_name, triton_uuid, key_id, created_at, updated_at, archived)
+);
+EOS
 
-    $SQL -d $env -e "CREATE TABLE IF NOT EXISTS tsg_users (
-id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-username STRING NOT NULL,
-account_id UUID NOT NULL REFERENCES tsg_accounts (id),
-created_at TIMESTAMPTZ NOT NULL,
-updated_at TIMESTAMPTZ NOT NULL,
-archived BOOL DEFAULT false);"
+    cat <<'EOS' | $SQL -d $env
+CREATE TABLE IF NOT EXISTS tsg_users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    username STRING NOT NULL,
+    account_id UUID NOT NULL REFERENCES tsg_accounts (id),
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    archived BOOL DEFAULT false
+);
+EOS
 
-    $SQL -d $env -e "CREATE TABLE IF NOT EXISTS tsg_templates (
-id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-template_name STRING NOT NULL,
-account_id UUID NOT NULL REFERENCES tsg_accounts (id),
-package STRING NOT NULL,
-image_id STRING NOT NULL,
-firewall_enabled BOOL DEFAULT false,
-networks TEXT,
-userdata TEXT,
-metadata TEXT,
-tags TEXT,
-created_at TIMESTAMPTZ NOT NULL,
-archived BOOL DEFAULT false,
-UNIQUE (template_name, account_id, archived));"
+    cat <<'EOS' | $SQL -d $env
+CREATE TABLE IF NOT EXISTS tsg_templates (
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
+    template_name STRING NOT NULL,
+    account_id UUID NOT NULL,
+    package STRING NOT NULL,
+    image_id STRING NOT NULL,
+    firewall_enabled BOOL NULL DEFAULT false,
+    networks STRING NULL,
+    userdata STRING NULL,
+    metadata STRING NULL,
+    tags STRING NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    archived BOOL NULL DEFAULT false,
+    CONSTRAINT "primary" PRIMARY KEY (id ASC),
+    CONSTRAINT account_id_tsg_accounts_id_fk FOREIGN KEY (account_id) REFERENCES tsg_accounts (id),
+    INDEX account_id_tsg_accounts_id_fk_idx (account_id ASC),
+    INDEX name_idx (template_name ASC),
+    INDEX archived_idx (archived ASC),
+    FAMILY "primary" (id, template_name, account_id, package, image_id, firewall_enabled, networks, userdata, metadata, tags, created_at, archived)
+);
+EOS
 
-    $SQL -d $env -e "CREATE TABLE IF NOT EXISTS tsg_groups (
-id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-name STRING NOT NULL,
-template_id UUID NOT NULL REFERENCES tsg_templates (id),
-account_id UUID NOT NULL REFERENCES tsg_accounts (id),
-capacity INT NOT NULL,
-health_check_interval INT DEFAULT 300,
-created_at TIMESTAMPTZ NOT NULL,
-updated_at TIMESTAMPTZ NOT NULL,
-archived BOOL DEFAULT false,
-UNIQUE (name, account_id, archived));"
+    cat <<'EOS' | $SQL -d $env
+CREATE TABLE IF NOT EXISTS tsg_groups (
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" STRING NOT NULL,
+    template_id UUID NOT NULL,
+    account_id UUID NOT NULL,
+    capacity INT NOT NULL,
+    health_check_interval INT NULL DEFAULT 300:::INT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    archived BOOL NULL DEFAULT false,
+    CONSTRAINT "primary" PRIMARY KEY (id ASC),
+    CONSTRAINT template_id_tsg_templates_id_fk FOREIGN KEY (template_id) REFERENCES tsg_templates (id),
+    CONSTRAINT account_id_tsg_accounts_id_fk FOREIGN KEY (account_id) REFERENCES tsg_accounts (id),
+    INDEX template_id_tsg_templates_id_fk_idx (template_id ASC),
+    INDEX account_id_tsg_accounts_id_fk_idx (account_id ASC),
+    INDEX name_idx ("name" ASC),
+    INDEX name_templates_id_idx ("name" ASC, template_id ASC),
+    INDEX archived_idx (archived ASC),
+    FAMILY "primary" (id, "name", template_id, account_id, capacity, health_check_interval, created_at, updated_at, archived)
+);
+EOS
 
     if [ -f /dev/backup.sql ]; then
         /cockroach/cockroach.sh sql $HOSTPARAMS --database=$env < /dev/backup.sql

--- a/groups/groups_db.go
+++ b/groups/groups_db.go
@@ -15,6 +15,30 @@ import (
 	"github.com/joyent/triton-service-groups/server/handlers"
 )
 
+func CheckGroupExistsByName(ctx context.Context, groupName, accountID string) (bool, error) {
+	db, ok := handlers.GetDBPool(ctx)
+	if !ok {
+		return false, handlers.ErrNoConnPool
+	}
+
+	var exists bool
+
+	sql := `
+SELECT EXISTS
+  (SELECT 1
+   FROM tsg_groups
+   WHERE (name = $1
+          AND account_id = $2)
+     AND archived IS FALSE);`
+
+	err := db.QueryRowEx(ctx, sql, nil, groupName, accountID).Scan(&exists)
+	if err != nil {
+		return false, err
+	}
+
+	return exists, nil
+}
+
 func FindGroups(ctx context.Context, accountID string) ([]*ServiceGroup, error) {
 	db, ok := handlers.GetDBPool(ctx)
 	if !ok {

--- a/templates/instance.go
+++ b/templates/instance.go
@@ -81,6 +81,18 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	templateExists, err := CheckTemplateExistsByName(ctx, template.TemplateName, session.AccountID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if templateExists {
+		http.Error(w, fmt.Sprintf("Cannot create template %q, "+
+			"conflicts with another template.", template.TemplateName),
+			http.StatusConflict)
+		return
+	}
+
 	err = SaveTemplate(ctx, session.AccountID, template)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -99,7 +111,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Location", path.Join(r.URL.Path, template.TemplateName))
+	w.Header().Set("Location", path.Join(r.URL.Path, com.ID))
 	writeJSONResponse(w, bytes, http.StatusCreated)
 }
 

--- a/templates/template_db.go
+++ b/templates/template_db.go
@@ -17,6 +17,30 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+func CheckTemplateExistsByName(ctx context.Context, templateName, accountID string) (bool, error) {
+	db, ok := handlers.GetDBPool(ctx)
+	if !ok {
+		return false, handlers.ErrNoConnPool
+	}
+
+	var exists bool
+
+	sql := `
+SELECT EXISTS
+  (SELECT 1
+   FROM tsg_templates
+   WHERE (template_name = $1
+          AND account_id = $2)
+     AND archived IS FALSE);`
+
+	err := db.QueryRowEx(ctx, sql, nil, templateName, accountID).Scan(&exists)
+	if err != nil {
+		return false, err
+	}
+
+	return exists, nil
+}
+
 func CheckTemplateAllocationByID(ctx context.Context, templateID, accountID string) (bool, error) {
 	db, ok := handlers.GetDBPool(ctx)
 	if !ok {


### PR DESCRIPTION
This commit aims to change the way how we handle creation of duplicate templates
and groups. Previously, we have used an unique constraint over fields like e.g.,
"name", "account_id" and "archived" (for a group), but because constraint was
trying to ensure that all the designated values, upon removing a group and
adding it back with the same name and account ID, the constraint would work
fine, but a deletion of such newly added group would fail, as there was already
a group like that deleted before (or archived, rather), thus the constraint
would trigger an error.

The change here is to add manual existence check during creation in order to
detect a possible none unique template or group being added, and if so, then
an error is returned back.

Additionally, we add number of indexes to all the tables.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>