### PR TITLE
Add validation to ensure non-empty group name.

### DIFF
--- a/groups/groups.go
+++ b/groups/groups.go
@@ -442,12 +442,16 @@ func decodeGroupResponseBodyAndValidate(body []byte) (*ServiceGroup, error) {
 		return nil, errors.New("error in unmarshal request body")
 	}
 
+	if group.GroupName == "" {
+		return nil, errors.New("group name cannot be empty")
+	}
+
 	if len(group.GroupName) > 182 {
 		return nil, errors.New("group name cannot be more than 182 characters")
 	}
 
 	if !isValidUUID(group.TemplateID) {
-		return nil, errors.New("templateID must be a valid UUID")
+		return nil, errors.New("template ID must be a valid UUID")
 	}
 
 	if group.Capacity < 0 {


### PR DESCRIPTION
This commit adds a group name validation, which is needed when sending a PUT
request against a group as an empty group name would result in a new task being
added on the Nomad side, but without any reference to an actual group name (or
the old group name, rather). This triggers a replacement of existing instances,
since not there is an additional periodic task in Nomad, where all of the new
instances would not have the `tsg.name` tag set. This means, that they can't
be managed any longer.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>