### PR TITLE
Support Base64 encoded values inside the Nomad job template.

### DIFF
--- a/groups/orchestrator_test.go
+++ b/groups/orchestrator_test.go
@@ -1,0 +1,62 @@
+package groups_v1
+
+import (
+	"testing"
+)
+
+func TestBase64Encode(t *testing.T) {
+	tests := []struct {
+		value   string
+		expeted string
+	}{
+		// No bytes to encode, thus no output.
+		{
+			"",
+			"",
+		},
+		{
+			"tsg",
+			"dHNn",
+		},
+	}
+
+	for _, tt := range tests {
+		actual := base64Encode(tt.value)
+		if tt.expeted != actual {
+			t.Errorf("expected value %#v, got %#v", tt.expeted, actual)
+		}
+	}
+
+}
+
+func TestEscapeNewlines(t *testing.T) {
+	tests := []struct {
+		value   string
+		expeted string
+	}{
+		{
+			"",
+			"",
+		},
+		{
+			"\n",
+			"\\n",
+		},
+		// Only escape LF (\n), as CR+LF (\r\n) is not supported.
+		{
+			"\r\n",
+			"\r\\n",
+		},
+		{
+			"\t",
+			"\t",
+		},
+	}
+
+	for _, tt := range tests {
+		actual := escapeNewlines(tt.value)
+		if tt.expeted != actual {
+			t.Errorf("expected value %#v, got %#v", tt.expeted, actual)
+		}
+	}
+}


### PR DESCRIPTION
This commit adds support for passing a Baste64 encoded values for a number of
CLI binary arguments in the Nomad job template such as `--userdata`, `--metadata`
and `--key-material`, as these often take values containing that can be very
problematic to use inside a template (e.g., contains newlines, special
characters, fragments of shell scripts, etc.).

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>